### PR TITLE
HttpResponse object

### DIFF
--- a/docs/advanced/additional_requests.rst
+++ b/docs/advanced/additional_requests.rst
@@ -53,12 +53,10 @@ A simple ``GET`` request
             }
 
             # Simulates clicking on a button that says "View All Images"
-            response: web_poet.ResponseData = await self.http_client.get(
+            response: web_poet.HttpResponse = await self.http_client.get(
                 f"https://api.example.com/v2/images?id={item['product_id']}"
             )
-            page = web_poet.WebPage(response)
-
-            item["images"] = page.css(".product-images img::attr(src)").getall()
+            item["images"] = response.css(".product-images img::attr(src)").getall()
             return item
 
 There are a few things to take note in this example:
@@ -66,11 +64,7 @@ There are a few things to take note in this example:
     * A ``GET`` request can be done via :class:`~.HttpClient`'s
       :meth:`~.HttpClient.get` method.
     * We're now using the ``async/await`` syntax.
-    * The response is of type :class:`~.ResponseData`.
-
-        * Though in order to use :meth:`~.ResponseShortcutsMixin.css`
-          `(and other shortcut methods)` we'll need to feed it into
-          :class:`~.WebPage`.
+    * The response is of type :class:`~.HttpResponse`.
 
 As the example suggests, we're performing an additional request that allows us
 to extract more images in a product page that might not otherwise be possible.
@@ -108,7 +102,7 @@ Thus, additional requests inside the Page Object is typically needed for it:
             }
 
             # Simulates "scrolling" through a carousel that loads related product items
-            response: web_poet.responseData = await self.http_client.post(
+            response = await self.http_client.post(
                 url="https://www.api.example.com/related-products/",
                 headers={
                     'Host': 'www.example.com',
@@ -121,15 +115,13 @@ Thus, additional requests inside the Page Object is typically needed for it:
                     }
                 ),
             )
-            second_page = web_poet.WebPage(response)
-
-            related_product_ids = self.parse_related_product_ids(second_page)
+            related_product_ids = self.parse_related_product_ids(response)
             item["related_product_ids"] = related_product_ids
             return item
 
         @staticmethod
-        def parse_related_product_ids(page: web_poet.WebPage) -> List[str]:
-            return page.css("#main .related-products ::attr(product-id)").getall()
+        def parse_related_product_ids(response: web_poet.HttpResponse) -> List[str]:
+            return response.css("#main .related-products ::attr(product-id)").getall()
 
 Here's the key takeaway in this example:
 
@@ -169,12 +161,11 @@ Let's modify the example in the previous section to see how it can be done:
                 self.create_request(page_num=page_num)
                 for page_num in range(2, default_pagination_limit)
             ]
-            responses: List[web_poet.ResponseData] = await self.http_client.batch_requests(*requests)
-            pages = map(web_poet.WebPage, responses)
+            responses: List[web_poet.HttpResponse] = await self.http_client.batch_requests(*requests)
             related_product_ids = [
                 product_id
-                for page in pages
-                for product_id in self.parse_related_product_ids(page)
+                for resp in responses
+                for product_id in self.parse_related_product_ids(resp)
             ]
 
             item["related_product_ids"].extend(related_product_ids)
@@ -198,7 +189,7 @@ Let's modify the example in the previous section to see how it can be done:
             )
 
         @staticmethod
-        def parse_related_product_ids(page: web_poet.WebPage) -> List[str]:
+        def parse_related_product_ids(response: web_poet.HttpResponse) -> List[str]:
             return page.css("#main .related-products ::attr(product-id)").getall()
 
 The key takeaways for this example are:
@@ -244,7 +235,7 @@ This can be set using:
 
 .. code-block:: python
 
-    def request_implementation(r: web_poet.Request) -> web_poet.ResponseData:
+    def request_implementation(r: web_poet.Request) -> web_poet.HttpResponse:
         ...
 
     from web_poet import request_backend_var
@@ -271,7 +262,7 @@ an :class:`~.HttpClient` instance:
 
 .. code-block:: python
 
-    def request_implementation(r: web_poet.Request) -> web_poet.ResponseData:
+    def request_implementation(r: web_poet.Request) -> web_poet.HttpResponse:
         ...
 
     from web_poet import HttpClient

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -36,28 +36,30 @@ list page on `books.toscrape.com <http://books.toscrape.com/>`_.
 Downloading Response
 ====================
 
-The ``BookLinksPage`` Page Object requires a :class:`~.ResponseData` with the
+The ``BookLinksPage`` Page Object requires a :class:`~.HttpResponse` with the
 book list page content in order to extract the information we need. Let's create
-a simple code using :mod:`urllib.request` to download the data.
+a simple code using ``requests`` library to download the data.
 
 .. code-block:: python
 
-    import urllib.request
+    import requests
 
 
-    response = urllib.request.urlopen('http://books.toscrape.com')
+    response = requests.get('http://books.toscrape.com')
 
 Creating Page Input
 ===================
 
-Now we need to create and populate a :class:`~.ResponseData` instance.
+Now we need to create and populate a :class:`~.HttpResponse` instance.
 
 .. code-block:: python
 
-    from web_poet.page_inputs import ResponseData
+    from web_poet.page_inputs import HttpResponse
 
 
-    response_data = ResponseData(response.url, response.read().decode('utf-8'))
+    response_data = HttpResponse(response.url,
+                                 body=response.content,
+                                 headers=response.headers)
     page = BookLinksPage(response_data)
 
     print(page.to_item())
@@ -72,7 +74,7 @@ Our simple Python script might look like this:
     import urllib.request
 
     from web_poet.pages import ItemWebPage
-    from web_poet.page_inputs import ResponseData
+    from web_poet.page_inputs import HttpResponse
 
 
     class BookLinksPage(ItemWebPage):
@@ -88,7 +90,10 @@ Our simple Python script might look like this:
 
 
     response = urllib.request.urlopen('http://books.toscrape.com')
-    response_data = ResponseData(response.url, response.read().decode('utf-8'))
+    response_data = HttpResponse(response.url,
+                                 body=response.content,
+                                 headers=response.headers)
+
     page = BookLinksPage(response_data)
 
     print(page.to_item())
@@ -126,7 +131,7 @@ Next Steps
 ==========
 
 As you can see, it's possible to use web-poet with built-in libraries such as
-:mod:`urllib.request`, but it's also possible to use
+``requests``, but it's also possible to use
 :ref:`Scrapy <scrapy:topics-index>` with the help of
 `scrapy-poet <https://scrapy-poet.readthedocs.io>`_.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from web_poet.page_inputs import ResponseData, HttpResponseBody
+from web_poet.page_inputs import HttpResponse, HttpResponseBody
 
 
 def read_fixture(path):
@@ -19,6 +19,6 @@ def book_list_html():
 @pytest.fixture
 def book_list_html_response(book_list_html):
     body = HttpResponseBody(bytes(book_list_html, "utf-8"))
-    return ResponseData(
-        url='http://books.toscrape.com/index.html', body=body, html=book_list_html
+    return HttpResponse(
+        url='http://books.toscrape.com/index.html', body=body, encoding="utf-8"
     )

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,11 +1,11 @@
 import pytest
 
 from web_poet.mixins import ResponseShortcutsMixin
-from web_poet.page_inputs import ResponseData, HttpResponseBody
+from web_poet.page_inputs import HttpResponse, HttpResponseBody
 
 
 class MyPage(ResponseShortcutsMixin):
-    def __init__(self, response: ResponseData):
+    def __init__(self, response: HttpResponse):
         self.response = response
 
 
@@ -42,7 +42,7 @@ def test_urljoin(my_page):
 
 
 def test_custom_baseurl():
-    html = """
+    html = b"""
     <html>
     <head>
         <base href="http://example.com/foo/">
@@ -50,11 +50,9 @@ def test_custom_baseurl():
     <body><body>
     </html>
     """
-    body = HttpResponseBody(bytes(html, "utf-8"))
-    response = ResponseData(
+    response = HttpResponse(
         url="http://www.example.com/path",
-        html=html,
-        body=body,
+        body=html,
     )
     page = MyPage(response=response)
 

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -1,18 +1,18 @@
-from web_poet.page_inputs import ResponseData, HttpResponseBody, HttpResponseHeaders
+from web_poet.page_inputs import HttpResponse, HttpResponseBody, HttpResponseHeaders
 
 
 def test_html_response():
-    html = "content"
     http_body = HttpResponseBody(b"content")
 
-    response = ResponseData("url", html, body=http_body)
+    response = HttpResponse("url", body=http_body)
     assert response.url == "url"
     assert response.body == b"content"
     assert response.status is None
-    assert response.headers is None
+    assert not response.headers
+    assert response.headers.get("user-agent") is None
 
     headers = HttpResponseHeaders.from_name_value_pairs([{"name": "User-Agent", "value": "test agent"}])
-    response = ResponseData("url", html, status=200, headers=headers)
+    response = HttpResponse("url", body=http_body, status=200, headers=headers)
     assert response.status == 200
     assert len(response.headers) == 1
     assert response.headers.get("user-agent") == "test agent"

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+import requests
 
 from web_poet.page_inputs import HttpResponse, HttpResponseBody, HttpResponseHeaders
 
@@ -83,3 +84,36 @@ def test_http_response_body_validation_other():
     with pytest.raises(TypeError):
         response = HttpResponse("http://example.com", body=123)
 
+
+def test_http_respose_headers():
+    headers = HttpResponseHeaders({"user-agent": "mozilla"})
+    assert headers['user-agent'] == "mozilla"
+    assert headers['User-Agent'] == "mozilla"
+
+    with pytest.raises(KeyError):
+        headers["user agent"]
+
+
+def test_http_response_headers_init_requests():
+    requests_response = requests.Response()
+    requests_response.headers['User-Agent'] = "mozilla"
+
+    response = HttpResponse("http://example.com", body=b"",
+                            headers=requests_response.headers)
+    assert isinstance(response.headers, HttpResponseHeaders)
+    assert response.headers['user-agent'] == "mozilla"
+    assert response.headers['User-Agent'] == "mozilla"
+
+
+def test_http_response_headers_init_dict():
+    response = HttpResponse("http://example.com", body=b"",
+                            headers={"user-agent": "mozilla"})
+    assert isinstance(response.headers, HttpResponseHeaders)
+    assert response.headers['user-agent'] == "mozilla"
+    assert response.headers['User-Agent'] == "mozilla"
+
+
+def test_http_response_headers_init_invalid():
+    with pytest.raises(TypeError):
+        response = HttpResponse("http://example.com", body=b"",
+                                headers=123)

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -42,7 +42,7 @@ def test_http_response_body_json():
     assert http_body.json() == {"ключ": "значение"}
 
 
-def test_html_response():
+def test_http_response_defaults():
     http_body = HttpResponseBody(b"content")
 
     response = HttpResponse("url", body=http_body)
@@ -52,8 +52,34 @@ def test_html_response():
     assert not response.headers
     assert response.headers.get("user-agent") is None
 
+
+def test_http_response_with_headers():
+    http_body = HttpResponseBody(b"content")
     headers = HttpResponseHeaders.from_name_value_pairs([{"name": "User-Agent", "value": "test agent"}])
     response = HttpResponse("url", body=http_body, status=200, headers=headers)
     assert response.status == 200
     assert len(response.headers) == 1
     assert response.headers.get("user-agent") == "test agent"
+
+
+def test_http_response_bytes_body():
+    response = HttpResponse("http://example.com", body=b"content")
+    assert isinstance(response.body, HttpResponseBody)
+    assert response.body == HttpResponseBody(b"content")
+
+
+def test_http_response_body_validation_str():
+    with pytest.raises(TypeError):
+        response = HttpResponse("http://example.com", body="content")
+
+
+def test_http_response_body_validation_None():
+    with pytest.raises(TypeError):
+        response = HttpResponse("http://example.com", body=None)
+
+
+@pytest.mark.xfail(reason="not implemented")
+def test_http_response_body_validation_other():
+    with pytest.raises(TypeError):
+        response = HttpResponse("http://example.com", body=123)
+

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -1,4 +1,45 @@
+import json
+
+import pytest
+
 from web_poet.page_inputs import HttpResponse, HttpResponseBody, HttpResponseHeaders
+
+
+def test_http_response_body_hashable():
+    http_body = HttpResponseBody(b"content")
+    assert http_body in {http_body}
+    assert http_body in {b"content"}
+    assert http_body not in {b"foo"}
+
+
+def test_http_response_body_bytes_api():
+    http_body = HttpResponseBody(b"content")
+    assert http_body == b"content"
+    assert b"ent" in http_body
+
+
+def test_http_response_body_declared_encoding():
+    http_body = HttpResponseBody(b"content")
+    assert http_body.declared_encoding() is None
+
+    http_body = HttpResponseBody(b"""
+    <html><head>
+    <meta charset="utf-8" />
+    </head></html>
+    """)
+    assert http_body.declared_encoding() == "utf-8"
+
+
+def test_http_response_body_json():
+    http_body = HttpResponseBody(b"contet")
+    with pytest.raises(json.JSONDecodeError):
+        data = http_body.json()
+
+    http_body = HttpResponseBody(b'{"foo": 123}')
+    assert http_body.json() == {"foo": 123}
+
+    http_body = HttpResponseBody('{"ключ": "значение"}'.encode("utf8"))
+    assert http_body.json() == {"ключ": "значение"}
 
 
 def test_html_response():

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -14,6 +14,7 @@ def test_abstract_web_page_object():
         ItemWebPage()
     assert "Can't instantiate abstract class" in str(exc.value)
 
+
 def test_page_object():
 
     class MyItemPage(ItemPage):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -15,7 +15,7 @@ def async_mock():
     """workaround since python 3.7 doesn't ship with asyncmock."""
 
     async def async_test(req):
-        return HttpResponse(req.url, req.body)
+        return HttpResponse(req.url, req.body or b'')
 
     mock.MagicMock.__await__ = lambda x: async_test().__await__()
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 import pytest
-from web_poet.page_inputs import ResponseData
+from web_poet.page_inputs import HttpResponse
 from web_poet.requests import (
     Request,
     HttpClient,
@@ -15,7 +15,7 @@ def async_mock():
     """workaround since python 3.7 doesn't ship with asyncmock."""
 
     async def async_test(req):
-        return ResponseData(req.url, req.body)
+        return HttpResponse(req.url, req.body)
 
     mock.MagicMock.__await__ = lambda x: async_test().__await__()
 
@@ -50,9 +50,9 @@ async def test_perform_request_from_httpclient(async_mock):
     request_backend_var.set(async_mock)
     response = await client.get(url)
 
-    # The async downloader implementation should return the ResponseData
+    # The async downloader implementation should return the HttpResponse
     assert response.url == url
-    assert type(response) == ResponseData
+    assert type(response) == HttpResponse
 
 
 @pytest.mark.asyncio
@@ -88,4 +88,4 @@ async def test_http_client_batch_requests(async_mock):
     ]
     responses = await client.batch_requests(*requests)
 
-    assert all([isinstance(response, ResponseData) for response in responses])
+    assert all([isinstance(response, HttpResponse) for response in responses])

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,8 @@ commands =
 
 [testenv:mypy]
 deps =
-    mypy
+    mypy==0.941
+    types-requests
 
 commands = mypy --ignore-missing-imports web_poet tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     pytest
     pytest-cov
     pytest-asyncio
+    requests
 
 commands =
     py.test \

--- a/web_poet/__init__.py
+++ b/web_poet/__init__.py
@@ -1,3 +1,3 @@
 from .pages import WebPage, ItemPage, ItemWebPage, Injectable
-from .page_inputs import ResponseData, HttpResponseBody, HttpResponseHeaders
+from .page_inputs import HttpResponse, HttpResponseBody, HttpResponseHeaders
 from .requests import request_backend_var, Request, HttpClient

--- a/web_poet/mixins.py
+++ b/web_poet/mixins.py
@@ -9,7 +9,6 @@ class ResponseShortcutsMixin:
 
     It requires "response" attribute to be present.
     """
-    _cached_selector = None
     _cached_base_url = None
 
     @property

--- a/web_poet/mixins.py
+++ b/web_poet/mixins.py
@@ -24,7 +24,9 @@ class ResponseShortcutsMixin:
     @property
     def selector(self) -> parsel.Selector:
         """``parsel.Selector`` instance for the HTML Response."""
-        return self.response.selector
+        # TODO: when dropping Python 3.7 support,
+        #  implement it using typing.Protocol
+        return self.response.selector  # type: ignore
 
     def xpath(self, query, **kwargs):
         """Run an XPath query on a response, using :class:`parsel.Selector`."""

--- a/web_poet/mixins.py
+++ b/web_poet/mixins.py
@@ -20,15 +20,12 @@ class ResponseShortcutsMixin:
     @property
     def html(self):
         """Shortcut to HTML Response's content."""
-        return self.response.html
+        return self.response.text
 
     @property
     def selector(self) -> parsel.Selector:
         """``parsel.Selector`` instance for the HTML Response."""
-        if self._cached_selector is None:
-            self._cached_selector = parsel.Selector(self.html)
-
-        return self._cached_selector
+        return self.response.selector
 
     def xpath(self, query, **kwargs):
         """Run an XPath query on a response, using :class:`parsel.Selector`."""
@@ -41,6 +38,7 @@ class ResponseShortcutsMixin:
     @property
     def base_url(self) -> str:
         """Return the base url of the given response"""
+        # FIXME: move it to HttpResponse
         if self._cached_base_url is None:
             text = self.html[:4096]
             self._cached_base_url = get_base_url(text, self.url)
@@ -49,4 +47,5 @@ class ResponseShortcutsMixin:
     def urljoin(self, url: str) -> str:
         """Convert url to absolute, taking in account
         url and baseurl of the response"""
+        # FIXME: move it to HttpResponse
         return urljoin(self.base_url, url)

--- a/web_poet/page_inputs.py
+++ b/web_poet/page_inputs.py
@@ -1,13 +1,34 @@
-from typing import Optional, Dict, List, Iterable, Tuple
+import json
+from typing import Optional, Dict, List
 
-import attr
+import attrs
 from multidict import CIMultiDict
+import parsel
+from w3lib.encoding import (
+    html_to_unicode,
+    html_body_declared_encoding,
+    resolve_encoding,
+    http_content_type_encoding
+)
+
+from .utils import memoizemethod_noargs
 
 
 class HttpResponseBody(bytes):
     """A container for holding the raw HTTP response body in bytes format."""
 
-    pass
+    @memoizemethod_noargs
+    def declared_encoding(self) -> Optional[str]:
+        """ Return the encoding specified in meta tags in the html body,
+        or ``None`` if no suitable encoding was found """
+        return html_body_declared_encoding(self)
+
+    @memoizemethod_noargs
+    def json(self):
+        """
+        Deserialize a JSON document to a Python object.
+        """
+        return json.loads(self)
 
 
 class HttpResponseHeaders(CIMultiDict):
@@ -53,18 +74,20 @@ class HttpResponseHeaders(CIMultiDict):
         """
         return cls([(pair["name"], pair["value"]) for pair in arg])
 
+    def declared_encoding(self) -> Optional[str]:
+        """ Return encoding detected from the Content-Type header, or None
+        if encoding is not found """
+        content_type = self.get('Content-Type', '')
+        return http_content_type_encoding(content_type)
 
-@attr.define
-class ResponseData:
+
+@attrs.define(auto_attribs=False)
+class HttpResponse:
     """A container for the contents of a response, downloaded directly using an
     HTTP client.
 
-    ``url`` should be an URL of the response (after all redirects),
-    not an URL of the request, if possible.
-
-    ``html`` should be content of the HTTP body, converted to unicode
-    using the detected encoding of the response, preferably according
-    to the web browser rules (respecting Content-Type header, etc.)
+    ``url`` should be a URL of the response (after all redirects),
+    not a URL of the request, if possible.
 
     ``body`` contains the raw HTTP response body.
 
@@ -76,10 +99,88 @@ class ResponseData:
     ``status`` should represent the int status code of the HTTP response.
 
     ``headers`` should contain the HTTP response headers.
+
+    ``encoding`` encoding of the response. If None (default), encoding
+    is auto-detected from headers and body content.
     """
 
-    url: str
-    html: str
-    body: Optional[HttpResponseBody] = None
-    status: Optional[int] = None
-    headers: Optional[HttpResponseHeaders] = None
+    url: str = attrs.field()
+    # FIXME: raise an error or handle the case when str is passed as body
+    body: HttpResponseBody = attrs.field(converter=HttpResponseBody)
+    status: Optional[int] = attrs.field(default=None)
+    headers: Optional[HttpResponseHeaders] = attrs.field(default=None)
+    _encoding: Optional[str] = attrs.field(default=None)
+
+    _DEFAULT_ENCODING = 'ascii'
+    _cached_text: Optional[str] = None
+
+    @property
+    def text(self) -> str:
+        """
+        Content of the HTTP body, converted to unicode
+        using the detected encoding of the response, according
+        to the web browser rules (respecting Content-Type header, etc.)
+        """
+        # Access self.encoding before self._cached_text, because
+        # there is a chance self._cached_text would be already populated
+        # while detecting the encoding
+        encoding = self.encoding
+        if self._cached_text is None:
+            fake_content_type_header = f'charset={encoding}'
+            encoding, text = html_to_unicode(fake_content_type_header, self.body)
+            self._cached_text = text
+        return self._cached_text
+
+    @property
+    def encoding(self):
+        """ Encoding of the response """
+        return (
+            self._encoding
+            or self._headers_declared_encoding()
+            or self._body_declared_encoding()
+            or self._body_inferred_encoding()
+        )
+
+    @property
+    @memoizemethod_noargs
+    def selector(self) -> parsel.Selector:
+        # XXX: should we pass base_url=self.url, as Scrapy does?
+        return parsel.Selector(text=self.text)
+
+    def xpath(self, query, **kwargs):
+        return self.selector.xpath(query, **kwargs)
+
+    def css(self, query):
+        return self.selector.css(query)
+
+    def json(self):
+        return self.body.json()
+
+    @memoizemethod_noargs
+    def _headers_declared_encoding(self):
+        if self.headers:
+            return self.headers.declared_encoding()
+
+    @memoizemethod_noargs
+    def _body_declared_encoding(self):
+        return self.body.declared_encoding()
+
+    @memoizemethod_noargs
+    def _body_inferred_encoding(self):
+        content_type = (self.headers or {}).get('Content-Type', '')
+        body_encoding, text = html_to_unicode(
+            content_type,
+            self.body,
+            auto_detect_fun=self._auto_detect_fun,
+            default_encoding=self._DEFAULT_ENCODING
+        )
+        self._cached_text = text
+        return body_encoding
+
+    def _auto_detect_fun(self, text):
+        for enc in (self._DEFAULT_ENCODING, 'utf-8', 'cp1252'):
+            try:
+                text.decode(enc)
+            except UnicodeError:
+                continue
+            return resolve_encoding(enc)

--- a/web_poet/page_inputs.py
+++ b/web_poet/page_inputs.py
@@ -79,7 +79,7 @@ class HttpResponseHeaders(CIMultiDict):
         return http_content_type_encoding(content_type)
 
 
-@attrs.define(auto_attribs=False, slots=False)
+@attrs.define(auto_attribs=False, slots=False, eq=False)
 class HttpResponse:
     """A container for the contents of a response, downloaded directly using an
     HTTP client.

--- a/web_poet/page_inputs.py
+++ b/web_poet/page_inputs.py
@@ -17,13 +17,11 @@ from .utils import memoizemethod_noargs
 class HttpResponseBody(bytes):
     """A container for holding the raw HTTP response body in bytes format."""
 
-    @memoizemethod_noargs
     def declared_encoding(self) -> Optional[str]:
         """ Return the encoding specified in meta tags in the html body,
         or ``None`` if no suitable encoding was found """
         return html_body_declared_encoding(self)
 
-    @memoizemethod_noargs
     def json(self):
         """
         Deserialize a JSON document to a Python object.
@@ -153,6 +151,7 @@ class HttpResponse:
     def css(self, query):
         return self.selector.css(query)
 
+    @memoizemethod_noargs
     def json(self):
         return self.body.json()
 

--- a/web_poet/page_inputs.py
+++ b/web_poet/page_inputs.py
@@ -139,7 +139,8 @@ class HttpResponse:
             or self._body_inferred_encoding()
         )
 
-    @property
+    # XXX: see https://github.com/python/mypy/issues/1362
+    @property   # type: ignore
     @memoizemethod_noargs
     def selector(self) -> parsel.Selector:
         # XXX: should we pass base_url=self.url, as Scrapy does?

--- a/web_poet/page_inputs.py
+++ b/web_poet/page_inputs.py
@@ -92,7 +92,7 @@ class HttpResponse:
     ``body`` contains the raw HTTP response body.
 
     The following are optional since it would depend on the source of the
-    ``ResponseData`` if these are available or not. For example, the responses
+    ``HttpResponse`` if these are available or not. For example, the responses
     could simply come off from a local HTML file which doesn't contain ``headers``
     and ``status``.
 

--- a/web_poet/page_inputs.py
+++ b/web_poet/page_inputs.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, TypeVar, Type
 
 import attrs
 from multidict import CIMultiDict
@@ -12,6 +12,8 @@ from w3lib.encoding import (
 )
 
 from .utils import memoizemethod_noargs
+
+T_headers = TypeVar("T_headers", bound="HttpResponseHeaders")
 
 
 class HttpResponseBody(bytes):
@@ -58,7 +60,7 @@ class HttpResponseHeaders(CIMultiDict):
     """
 
     @classmethod
-    def from_name_value_pairs(cls, arg: List[Dict]):
+    def from_name_value_pairs(cls: Type[T_headers], arg: List[Dict]) -> T_headers:
         """An alternative constructor for instantiation using a ``List[Dict]``
         where the 'key' is the header name while the 'value' is the header value.
 

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -3,7 +3,7 @@ import attr
 import typing
 
 from web_poet.mixins import ResponseShortcutsMixin
-from web_poet.page_inputs import ResponseData
+from web_poet.page_inputs import HttpResponse
 
 
 class Injectable(abc.ABC):
@@ -45,13 +45,13 @@ class ItemPage(Injectable, abc.ABC):
 
 @attr.s(auto_attribs=True)
 class WebPage(Injectable, ResponseShortcutsMixin):
-    """Base Page Object which requires :class:`~.ResponseData`
+    """Base Page Object which requires :class:`~.HttpResponse`
     and provides XPath / CSS shortcuts.
 
     Use this class as a base class for Page Objects which work on
     HTML downloaded using an HTTP client directly.
     """
-    response: ResponseData
+    response: HttpResponse
 
 
 @attr.s(auto_attribs=True)

--- a/web_poet/requests.py
+++ b/web_poet/requests.py
@@ -50,13 +50,13 @@ class Request:
     body: Optional[str] = None
 
 
-async def _perform_request(request: Request) -> ResponseData:
+async def _perform_request(request: Request) -> HttpResponse:
     """Given a :class:`~.Request`, execute it using the **request implementation**
     that was set in the ``web_poet.request_backend_var`` :mod:`contextvars`
     instance.
 
     .. warning::
-        By convention, this function should return a :class:`~.ResponseData`.
+        By convention, this function should return a :class:`~.HttpResponse`.
         However, the underlying downloader assigned in
         ``web_poet.request_backend_var`` might change that, depending on
         how the framework using **web-poet** implements it.
@@ -73,7 +73,7 @@ async def _perform_request(request: Request) -> ResponseData:
             "'web_poet.request_backend_var'"
         )
 
-    response_data: ResponseData = await request_backend(request)
+    response_data: HttpResponse = await request_backend(request)
     return response_data
 
 
@@ -91,7 +91,7 @@ class HttpClient:
 
     In any case, this doesn't contain any implementation about how to execute
     any requests fed into it. When setting that up, make sure that the downloader
-    implementation returns a :class:`~.ResponseData` instance.
+    implementation returns a :class:`~.HttpResponse` instance.
     """
 
     def __init__(self, request_downloader: Callable = None):
@@ -103,22 +103,22 @@ class HttpClient:
         method: str = "GET",
         headers: Optional[mapping] = None,
         body: Optional[str] = None,
-    ) -> ResponseData:
+    ) -> HttpResponse:
         """This is a shortcut for creating a :class:`Request` instance and executing
         that request.
 
-        A :class:`~.ResponseData` instance should then be returned.
+        A :class:`~.HttpResponse` instance should then be returned.
 
         .. warning::
             By convention, the request implementation supplied optionally to
-            :class:`~.HttpClient` should return a :class:`~.ResponseData` instance.
+            :class:`~.HttpClient` should return a :class:`~.HttpResponse` instance.
             However, the underlying implementation supplied might change that,
             depending on how the framework using **web-poet** implements it.
         """
         r = Request(url, method, headers, body)
         return await self.request_downloader(r)
 
-    async def get(self, url: str, headers: Optional[mapping] = None) -> ResponseData:
+    async def get(self, url: str, headers: Optional[mapping] = None) -> HttpResponse:
         """Similar to :meth:`~.HttpClient.request` but peforming a ``GET``
         request.
         """
@@ -126,13 +126,13 @@ class HttpClient:
 
     async def post(
         self, url: str, headers: Optional[mapping] = None, body: Optional[str] = None
-    ) -> ResponseData:
+    ) -> HttpResponse:
         """Similar to :meth:`~.HttpClient.request` but peforming a ``POST``
         request.
         """
         return await self.request(url=url, method="POST", headers=headers, body=body)
 
-    async def batch_requests(self, *requests: Request) -> List[ResponseData]:
+    async def batch_requests(self, *requests: Request) -> List[HttpResponse]:
         """Similar to :meth:`~.HttpClient.request` but accepts a collection of
         :class:`~.Request` instances that would be batch executed.
         """

--- a/web_poet/requests.py
+++ b/web_poet/requests.py
@@ -15,7 +15,7 @@ from typing import Optional, List, Dict, ByteString, Any, Union, Callable
 
 import attr
 
-from web_poet.page_inputs import ResponseData
+from web_poet.page_inputs import HttpResponse
 
 logger = logging.getLogger(__name__)
 

--- a/web_poet/utils.py
+++ b/web_poet/utils.py
@@ -1,0 +1,17 @@
+import weakref
+from functools import wraps
+
+
+def memoizemethod_noargs(method):
+    """Decorator to cache the result of a method (without arguments) using a
+    weak reference to its object
+    """
+    cache = weakref.WeakKeyDictionary()
+
+    @wraps(method)
+    def new_method(self, *args, **kwargs):
+        if self not in cache:
+            cache[self] = method(self, *args, **kwargs)
+        return cache[self]
+
+    return new_method


### PR DESCRIPTION
hey @BurnzZ! This is a follow-up to https://github.com/scrapinghub/web-poet/pull/24:

* useful utilities are ported from Scrapy's Response and TextResponse
* ResponseData is renamed to HttpResponse

I haven't checked if the code works :) Also, it's not a copy-paste port from Scrapy; the code is cleaned up and adjusted (which could mean new bugs).

Not handled here:

* there is overlapping code in ResponseShortcutsMixin, I haven't touched it.
* because of the above, response.urljoin is not implemented
* there are some FIXME's in the code
* tests and docs are broken
* we'd need to think about code organization when we add support for BrowserHtml type. There will be a lot of duplication.