### PR TITLE
HttpResponse instead of ResponseData

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ TBR
 
 * removed support for Python 3.6
 * added support for Python 3.10
+* Backward Incompatible Change:
+
+    * ``ResponseData`` is now ``HttpResponse`` which has a new
+      specific attribute types like ``HttpResponseBody`` and
+      ``HttpResponseHeaders``.
 
 
 0.1.1 (2021-06-02)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -192,4 +192,5 @@ autodoc_member_order = "bysource"
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None, ),
     'scrapy': ('https://docs.scrapy.org/en/latest', None, ),
+    'parsel': ('https://parsel.readthedocs.io/en/latest/', None, ),
 }

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -36,28 +36,30 @@ list page on `books.toscrape.com <http://books.toscrape.com/>`_.
 Downloading Response
 ====================
 
-The ``BookLinksPage`` Page Object requires a :class:`~.ResponseData` with the
+The ``BookLinksPage`` Page Object requires a :class:`~.HttpResponse` with the
 book list page content in order to extract the information we need. Let's create
-a simple code using :mod:`urllib.request` to download the data.
+a simple code using ``requests`` library to download the data.
 
 .. code-block:: python
 
-    import urllib.request
+    import requests
 
 
-    response = urllib.request.urlopen('http://books.toscrape.com')
+    response = requests.get('http://books.toscrape.com')
 
 Creating Page Input
 ===================
 
-Now we need to create and populate a :class:`~.ResponseData` instance.
+Now we need to create and populate a :class:`~.HttpResponse` instance.
 
 .. code-block:: python
 
-    from web_poet.page_inputs import ResponseData
+    from web_poet.page_inputs import HttpResponse
 
 
-    response_data = ResponseData(response.url, response.read().decode('utf-8'))
+    response_data = HttpResponse(response.url,
+                                 body=response.content,
+                                 headers=response.headers)
     page = BookLinksPage(response_data)
 
     print(page.to_item())
@@ -72,7 +74,7 @@ Our simple Python script might look like this:
     import urllib.request
 
     from web_poet.pages import ItemWebPage
-    from web_poet.page_inputs import ResponseData
+    from web_poet.page_inputs import HttpResponse
 
 
     class BookLinksPage(ItemWebPage):
@@ -88,7 +90,10 @@ Our simple Python script might look like this:
 
 
     response = urllib.request.urlopen('http://books.toscrape.com')
-    response_data = ResponseData(response.url, response.read().decode('utf-8'))
+    response_data = HttpResponse(response.url,
+                                 body=response.content,
+                                 headers=response.headers)
+
     page = BookLinksPage(response_data)
 
     print(page.to_item())
@@ -126,7 +131,7 @@ Next Steps
 ==========
 
 As you can see, it's possible to use web-poet with built-in libraries such as
-:mod:`urllib.request`, but it's also possible to use
+``requests``, but it's also possible to use
 :ref:`Scrapy <scrapy:topics-index>` with the help of
 `scrapy-poet <https://scrapy-poet.readthedocs.io>`_.
 

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -71,7 +71,7 @@ Our simple Python script might look like this:
 
 .. code-block:: python
 
-    import urllib.request
+    import requests
 
     from web_poet.pages import ItemWebPage
     from web_poet.page_inputs import HttpResponse
@@ -89,7 +89,7 @@ Our simple Python script might look like this:
             }
 
 
-    response = urllib.request.urlopen('http://books.toscrape.com')
+    response = requests.get('http://books.toscrape.com')
     response_data = HttpResponse(response.url,
                                  body=response.content,
                                  headers=response.headers)

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -36,9 +36,10 @@ list page on `books.toscrape.com <http://books.toscrape.com/>`_.
 Downloading Response
 ====================
 
-The ``BookLinksPage`` Page Object requires a :class:`~.HttpResponse` with the
-book list page content in order to extract the information we need. Let's create
-a simple code using ``requests`` library to download the data.
+The ``BookLinksPage`` Page Object requires a
+:class:`~.HttpResponse` with the
+book list page content in order to extract the information we need. First,
+let's download the page using ``requests`` library.
 
 .. code-block:: python
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==4.3.2
+Sphinx==4.4.0
 sphinx-rtd-theme==1.0.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst') as f:
 setup(
     name='web-poet',
     version='0.1.1',
-    description="Scrapinghub's Page Object pattern for web scraping",
+    description="Zyte's Page Object pattern for web scraping",
     long_description=long_description,
     long_description_content_type='text/x-rst',
     author='Scrapinghub',

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,13 @@ setup(
             'tests',
         )
     ),
-    install_requires=(
+    install_requires=[
         'attrs',
         'parsel',
         'multidict',
-    ),
-    classifiers=(
+        'w3lib >= 1.22.0',
+    ],
+    classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
@@ -35,5 +36,5 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
-    ),
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         )
     ),
     install_requires=[
-        'attrs',
+        'attrs >= 21.3.0',
         'parsel',
         'multidict',
         'w3lib >= 1.22.0',

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     install_requires=(
         'attrs',
         'parsel',
+        'multidict',
     ),
     classifiers=(
         'Development Status :: 2 - Pre-Alpha',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from web_poet.page_inputs import ResponseData
+from web_poet.page_inputs import HttpResponse, HttpResponseBody
 
 
 def read_fixture(path):
@@ -18,4 +18,7 @@ def book_list_html():
 
 @pytest.fixture
 def book_list_html_response(book_list_html):
-    return ResponseData('http://books.toscrape.com/index.html', book_list_html)
+    body = HttpResponseBody(bytes(book_list_html, "utf-8"))
+    return HttpResponse(
+        url='http://books.toscrape.com/index.html', body=body, encoding="utf-8"
+    )

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -42,7 +42,7 @@ def test_urljoin(my_page):
 
 
 def test_custom_baseurl():
-    html = b"""
+    body = b"""
     <html>
     <head>
         <base href="http://example.com/foo/">
@@ -52,7 +52,7 @@ def test_custom_baseurl():
     """
     response = HttpResponse(
         url="http://www.example.com/path",
-        body=html,
+        body=body,
     )
     page = MyPage(response=response)
 

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,12 +1,11 @@
 import pytest
 
 from web_poet.mixins import ResponseShortcutsMixin
-from web_poet.page_inputs import ResponseData
+from web_poet.page_inputs import HttpResponse, HttpResponseBody
 
 
 class MyPage(ResponseShortcutsMixin):
-
-    def __init__(self, response: ResponseData):
+    def __init__(self, response: HttpResponse):
         self.response = response
 
 
@@ -43,7 +42,7 @@ def test_urljoin(my_page):
 
 
 def test_custom_baseurl():
-    html = """
+    html = b"""
     <html>
     <head>
         <base href="http://example.com/foo/">
@@ -51,9 +50,9 @@ def test_custom_baseurl():
     <body><body>
     </html>
     """
-    response = ResponseData(
+    response = HttpResponse(
         url="http://www.example.com/path",
-        html=html,
+        body=html,
     )
     page = MyPage(response=response)
 

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -1,5 +1,6 @@
 import json
 
+import aiohttp.web_response
 import pytest
 import requests
 
@@ -100,6 +101,17 @@ def test_http_response_headers_init_requests():
 
     response = HttpResponse("http://example.com", body=b"",
                             headers=requests_response.headers)
+    assert isinstance(response.headers, HttpResponseHeaders)
+    assert response.headers['user-agent'] == "mozilla"
+    assert response.headers['User-Agent'] == "mozilla"
+
+
+def test_http_response_headers_init_aiohttp():
+    aiohttp_response = aiohttp.web_response.Response()
+    aiohttp_response.headers['User-Agent'] = "mozilla"
+
+    response = HttpResponse("http://example.com", body=b"",
+                            headers=aiohttp_response.headers)
     assert isinstance(response.headers, HttpResponseHeaders)
     assert response.headers['user-agent'] == "mozilla"
     assert response.headers['User-Agent'] == "mozilla"

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -215,10 +215,7 @@ def test_invalid_utf8_encoded_body_with_valid_utf8_BOM():
                             headers={"Content-type": "text/html; charset=utf-8"},
                             body=b"\xef\xbb\xbfWORD\xe3\xab")
     assert response.encoding == "utf-8"
-    assert response.text in {
-        'WORD\ufffd\ufffd',  # w3lib < 1.19.0
-        'WORD\ufffd',        # w3lib >= 1.19.0
-    }
+    assert response.text == 'WORD\ufffd'
 
 
 def test_bom_is_removed_from_body():

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -1,7 +1,119 @@
-from web_poet.page_inputs import ResponseData
+import json
+
+import pytest
+import requests
+
+from web_poet.page_inputs import HttpResponse, HttpResponseBody, HttpResponseHeaders
 
 
-def test_html_response():
-    response = ResponseData('url', 'content')
-    assert response.url == 'url'
-    assert response.html == 'content'
+def test_http_response_body_hashable():
+    http_body = HttpResponseBody(b"content")
+    assert http_body in {http_body}
+    assert http_body in {b"content"}
+    assert http_body not in {b"foo"}
+
+
+def test_http_response_body_bytes_api():
+    http_body = HttpResponseBody(b"content")
+    assert http_body == b"content"
+    assert b"ent" in http_body
+
+
+def test_http_response_body_declared_encoding():
+    http_body = HttpResponseBody(b"content")
+    assert http_body.declared_encoding() is None
+
+    http_body = HttpResponseBody(b"""
+    <html><head>
+    <meta charset="utf-8" />
+    </head></html>
+    """)
+    assert http_body.declared_encoding() == "utf-8"
+
+
+def test_http_response_body_json():
+    http_body = HttpResponseBody(b"contet")
+    with pytest.raises(json.JSONDecodeError):
+        data = http_body.json()
+
+    http_body = HttpResponseBody(b'{"foo": 123}')
+    assert http_body.json() == {"foo": 123}
+
+    http_body = HttpResponseBody('{"ключ": "значение"}'.encode("utf8"))
+    assert http_body.json() == {"ключ": "значение"}
+
+
+def test_http_response_defaults():
+    http_body = HttpResponseBody(b"content")
+
+    response = HttpResponse("url", body=http_body)
+    assert response.url == "url"
+    assert response.body == b"content"
+    assert response.status is None
+    assert not response.headers
+    assert response.headers.get("user-agent") is None
+
+
+def test_http_response_with_headers():
+    http_body = HttpResponseBody(b"content")
+    headers = HttpResponseHeaders.from_name_value_pairs([{"name": "User-Agent", "value": "test agent"}])
+    response = HttpResponse("url", body=http_body, status=200, headers=headers)
+    assert response.status == 200
+    assert len(response.headers) == 1
+    assert response.headers.get("user-agent") == "test agent"
+
+
+def test_http_response_bytes_body():
+    response = HttpResponse("http://example.com", body=b"content")
+    assert isinstance(response.body, HttpResponseBody)
+    assert response.body == HttpResponseBody(b"content")
+
+
+def test_http_response_body_validation_str():
+    with pytest.raises(TypeError):
+        response = HttpResponse("http://example.com", body="content")
+
+
+def test_http_response_body_validation_None():
+    with pytest.raises(TypeError):
+        response = HttpResponse("http://example.com", body=None)
+
+
+@pytest.mark.xfail(reason="not implemented")
+def test_http_response_body_validation_other():
+    with pytest.raises(TypeError):
+        response = HttpResponse("http://example.com", body=123)
+
+
+def test_http_respose_headers():
+    headers = HttpResponseHeaders({"user-agent": "mozilla"})
+    assert headers['user-agent'] == "mozilla"
+    assert headers['User-Agent'] == "mozilla"
+
+    with pytest.raises(KeyError):
+        headers["user agent"]
+
+
+def test_http_response_headers_init_requests():
+    requests_response = requests.Response()
+    requests_response.headers['User-Agent'] = "mozilla"
+
+    response = HttpResponse("http://example.com", body=b"",
+                            headers=requests_response.headers)
+    assert isinstance(response.headers, HttpResponseHeaders)
+    assert response.headers['user-agent'] == "mozilla"
+    assert response.headers['User-Agent'] == "mozilla"
+
+
+def test_http_response_headers_init_dict():
+    response = HttpResponse("http://example.com", body=b"",
+                            headers={"user-agent": "mozilla"})
+    assert isinstance(response.headers, HttpResponseHeaders)
+    assert response.headers['user-agent'] == "mozilla"
+    assert response.headers['User-Agent'] == "mozilla"
+
+
+def test_http_response_headers_init_invalid():
+    with pytest.raises(TypeError):
+        response = HttpResponse("http://example.com", body=b"",
+                                headers=123)

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -14,6 +14,7 @@ def test_abstract_web_page_object():
         ItemWebPage()
     assert "Can't instantiate abstract class" in str(exc.value)
 
+
 def test_page_object():
 
     class MyItemPage(ItemPage):

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     pytest
     pytest-cov
     requests
+    aiohttp
 
 commands =
     py.test \

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,10 @@ deps =
     mypy==0.941
     types-requests
 
-commands = mypy --ignore-missing-imports web_poet tests
+commands = mypy \
+    --ignore-missing-imports \
+    --no-warn-no-return \
+   web_poet tests
 
 [docs]
 changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py37,py38,py39,py310,mypy,docs
 deps =
     pytest
     pytest-cov
+    requests
 
 commands =
     py.test \
@@ -14,7 +15,8 @@ commands =
 
 [testenv:mypy]
 deps =
-    mypy
+    mypy==0.941
+    types-requests
 
 commands = mypy --ignore-missing-imports web_poet tests
 

--- a/web_poet/__init__.py
+++ b/web_poet/__init__.py
@@ -1,2 +1,2 @@
 from .pages import WebPage, ItemPage, ItemWebPage, Injectable
-from .page_inputs import ResponseData
+from .page_inputs import HttpResponse, HttpResponseBody, HttpResponseHeaders

--- a/web_poet/mixins.py
+++ b/web_poet/mixins.py
@@ -9,7 +9,6 @@ class ResponseShortcutsMixin:
 
     It requires "response" attribute to be present.
     """
-    _cached_selector = None
     _cached_base_url = None
 
     @property
@@ -20,15 +19,14 @@ class ResponseShortcutsMixin:
     @property
     def html(self):
         """Shortcut to HTML Response's content."""
-        return self.response.html
+        return self.response.text
 
     @property
     def selector(self) -> parsel.Selector:
         """``parsel.Selector`` instance for the HTML Response."""
-        if self._cached_selector is None:
-            self._cached_selector = parsel.Selector(self.html)
-
-        return self._cached_selector
+        # TODO: when dropping Python 3.7 support,
+        #  implement it using typing.Protocol
+        return self.response.selector  # type: ignore
 
     def xpath(self, query, **kwargs):
         """Run an XPath query on a response, using :class:`parsel.Selector`."""
@@ -41,6 +39,7 @@ class ResponseShortcutsMixin:
     @property
     def base_url(self) -> str:
         """Return the base url of the given response"""
+        # FIXME: move it to HttpResponse
         if self._cached_base_url is None:
             text = self.html[:4096]
             self._cached_base_url = get_base_url(text, self.url)
@@ -49,5 +48,5 @@ class ResponseShortcutsMixin:
     def urljoin(self, url: str) -> str:
         """Convert url to absolute, taking in account
         url and baseurl of the response"""
+        # FIXME: move it to HttpResponse
         return urljoin(self.base_url, url)
-

--- a/web_poet/page_inputs.py
+++ b/web_poet/page_inputs.py
@@ -1,17 +1,187 @@
-import attr
+import json
+from typing import Optional, Dict, List, TypeVar, Type
+
+import attrs
+from multidict import CIMultiDict
+import parsel
+from w3lib.encoding import (
+    html_to_unicode,
+    html_body_declared_encoding,
+    resolve_encoding,
+    http_content_type_encoding
+)
+
+from .utils import memoizemethod_noargs
+
+T_headers = TypeVar("T_headers", bound="HttpResponseHeaders")
 
 
-@attr.s(auto_attribs=True)
-class ResponseData:
-    """A container for URL and HTML content of a response, downloaded
-    directly using an HTTP client.
+class HttpResponseBody(bytes):
+    """A container for holding the raw HTTP response body in bytes format."""
 
-    ``url`` should be an URL of the response (after all redirects),
-    not an URL of the request, if possible.
+    def declared_encoding(self) -> Optional[str]:
+        """ Return the encoding specified in meta tags in the html body,
+        or ``None`` if no suitable encoding was found """
+        return html_body_declared_encoding(self)
 
-    ``html`` should be content of the HTTP body, converted to unicode
-    using the detected encoding of the response, preferably according
-    to the web browser rules (respecting Content-Type header, etc.)
+    def json(self):
+        """
+        Deserialize a JSON document to a Python object.
+        """
+        return json.loads(self)
+
+
+class HttpResponseHeaders(CIMultiDict):
+    """A container for holding the HTTP response headers.
+
+    It's able to accept instantiation via an Iterable of Tuples:
+
+    >>> pairs = [("Content-Encoding", "gzip"), ("content-length", "648")]
+    >>> HttpResponseHeaders(pairs)
+    <HttpResponseHeaders('Content-Encoding': 'gzip', 'content-length': '648')>
+
+    It's also accepts a mapping of key-value pairs as well:
+
+    >>> pairs = {"Content-Encoding": "gzip", "content-length": "648"}
+    >>> headers = HttpResponseHeaders(pairs)
+    >>> headers
+    <HttpResponseHeaders('Content-Encoding': 'gzip', 'content-length': '648')>
+
+    Note that this also supports case insensitive header-key lookups:
+
+    >>> headers.get("content-encoding")
+    'gzip'
+    >>> headers.get("Content-Length")
+    '648'
+
+    These are just a few of the functionalities it inherits from
+    :class:`multidict.CIMultiDict`. For more info on its other features, read
+    the API spec of :class:`multidict.CIMultiDict`.
     """
-    url: str
-    html: str
+
+    @classmethod
+    def from_name_value_pairs(cls: Type[T_headers], arg: List[Dict]) -> T_headers:
+        """An alternative constructor for instantiation using a ``List[Dict]``
+        where the 'key' is the header name while the 'value' is the header value.
+
+        >>> pairs = [
+        ...     {"name": "Content-Encoding", "value": "gzip"},
+        ...     {"name": "content-length", "value": "648"}
+        ... ]
+        >>> headers = HttpResponseHeaders.from_name_value_pairs(pairs)
+        >>> headers
+        <HttpResponseHeaders('Content-Encoding': 'gzip', 'content-length': '648')>
+        """
+        return cls([(pair["name"], pair["value"]) for pair in arg])
+
+    def declared_encoding(self) -> Optional[str]:
+        """ Return encoding detected from the Content-Type header, or None
+        if encoding is not found """
+        content_type = self.get('Content-Type', '')
+        return http_content_type_encoding(content_type)
+
+
+@attrs.define(auto_attribs=False, slots=False, eq=False)
+class HttpResponse:
+    """A container for the contents of a response, downloaded directly using an
+    HTTP client.
+
+    ``url`` should be a URL of the response (after all redirects),
+    not a URL of the request, if possible.
+
+    ``body`` contains the raw HTTP response body.
+
+    The following are optional since it would depend on the source of the
+    ``HttpResponse`` if these are available or not. For example, the responses
+    could simply come off from a local HTML file which doesn't contain ``headers``
+    and ``status``.
+
+    ``status`` should represent the int status code of the HTTP response.
+
+    ``headers`` should contain the HTTP response headers.
+
+    ``encoding`` encoding of the response. If None (default), encoding
+    is auto-detected from headers and body content.
+    """
+
+    url: str = attrs.field()
+    body: HttpResponseBody = attrs.field(converter=HttpResponseBody)
+    status: Optional[int] = attrs.field(default=None)
+    headers: HttpResponseHeaders = attrs.field(factory=HttpResponseHeaders,
+                                               converter=HttpResponseHeaders)
+    _encoding: Optional[str] = attrs.field(default=None)
+
+    _DEFAULT_ENCODING = 'ascii'
+    _cached_text: Optional[str] = None
+
+    @property
+    def text(self) -> str:
+        """
+        Content of the HTTP body, converted to unicode
+        using the detected encoding of the response, according
+        to the web browser rules (respecting Content-Type header, etc.)
+        """
+        # Access self.encoding before self._cached_text, because
+        # there is a chance self._cached_text would be already populated
+        # while detecting the encoding
+        encoding = self.encoding
+        if self._cached_text is None:
+            fake_content_type_header = f'charset={encoding}'
+            encoding, text = html_to_unicode(fake_content_type_header, self.body)
+            self._cached_text = text
+        return self._cached_text
+
+    @property
+    def encoding(self):
+        """ Encoding of the response """
+        return (
+            self._encoding
+            or self._headers_declared_encoding()
+            or self._body_declared_encoding()
+            or self._body_inferred_encoding()
+        )
+
+    # XXX: see https://github.com/python/mypy/issues/1362
+    @property   # type: ignore
+    @memoizemethod_noargs
+    def selector(self) -> parsel.Selector:
+        # XXX: should we pass base_url=self.url, as Scrapy does?
+        return parsel.Selector(text=self.text)
+
+    def xpath(self, query, **kwargs):
+        return self.selector.xpath(query, **kwargs)
+
+    def css(self, query):
+        return self.selector.css(query)
+
+    @memoizemethod_noargs
+    def json(self):
+        return self.body.json()
+
+    @memoizemethod_noargs
+    def _headers_declared_encoding(self):
+        return self.headers.declared_encoding()
+
+    @memoizemethod_noargs
+    def _body_declared_encoding(self):
+        return self.body.declared_encoding()
+
+    @memoizemethod_noargs
+    def _body_inferred_encoding(self):
+        content_type = self.headers.get('Content-Type', '')
+        body_encoding, text = html_to_unicode(
+            content_type,
+            self.body,
+            auto_detect_fun=self._auto_detect_fun,
+            default_encoding=self._DEFAULT_ENCODING
+        )
+        self._cached_text = text
+        return body_encoding
+
+    def _auto_detect_fun(self, text):
+        for enc in (self._DEFAULT_ENCODING, 'utf-8', 'cp1252'):
+            try:
+                text.decode(enc)
+            except UnicodeError:
+                continue
+            return resolve_encoding(enc)

--- a/web_poet/page_inputs.py
+++ b/web_poet/page_inputs.py
@@ -189,4 +189,3 @@ class HttpResponse:
             except UnicodeError:
                 continue
             return resolve_encoding(enc)
-        return None

--- a/web_poet/page_inputs.py
+++ b/web_poet/page_inputs.py
@@ -145,7 +145,7 @@ class HttpResponse:
     @property   # type: ignore
     @memoizemethod_noargs
     def selector(self) -> parsel.Selector:
-        """Returns a cached instance to :external:class:`parsel.selector.Selector`."""
+        """Cached instance of :external:class:`parsel.selector.Selector`."""
         # XXX: should we pass base_url=self.url, as Scrapy does?
         return parsel.Selector(text=self.text)
 
@@ -159,7 +159,7 @@ class HttpResponse:
 
     @memoizemethod_noargs
     def json(self):
-        """Returns the Python ``dict`` representation of the Http Response body."""
+        """ Deserialize a JSON document to a Python object. """
         return self.body.json()
 
     @memoizemethod_noargs

--- a/web_poet/page_inputs.py
+++ b/web_poet/page_inputs.py
@@ -182,10 +182,11 @@ class HttpResponse:
         self._cached_text = text
         return body_encoding
 
-    def _auto_detect_fun(self, text):
+    def _auto_detect_fun(self, body: bytes) -> Optional[str]:
         for enc in (self._DEFAULT_ENCODING, 'utf-8', 'cp1252'):
             try:
-                text.decode(enc)
+                body.decode(enc)
             except UnicodeError:
                 continue
             return resolve_encoding(enc)
+        return None

--- a/web_poet/page_inputs.py
+++ b/web_poet/page_inputs.py
@@ -145,17 +145,21 @@ class HttpResponse:
     @property   # type: ignore
     @memoizemethod_noargs
     def selector(self) -> parsel.Selector:
+        """Returns a cached instance to :external:class:`parsel.selector.Selector`."""
         # XXX: should we pass base_url=self.url, as Scrapy does?
         return parsel.Selector(text=self.text)
 
     def xpath(self, query, **kwargs):
+        """A shortcut to ``HttpResponse.selector.xpath()``."""
         return self.selector.xpath(query, **kwargs)
 
     def css(self, query):
+        """A shortcut to ``HttpResponse.selector.css()``."""
         return self.selector.css(query)
 
     @memoizemethod_noargs
     def json(self):
+        """Returns the Python ``dict`` representation of the Http Response body."""
         return self.body.json()
 
     @memoizemethod_noargs

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -3,7 +3,7 @@ import attr
 import typing
 
 from web_poet.mixins import ResponseShortcutsMixin
-from web_poet.page_inputs import ResponseData
+from web_poet.page_inputs import HttpResponse
 
 
 class Injectable(abc.ABC):
@@ -45,13 +45,13 @@ class ItemPage(Injectable, abc.ABC):
 
 @attr.s(auto_attribs=True)
 class WebPage(Injectable, ResponseShortcutsMixin):
-    """Base Page Object which requires :class:`~.ResponseData`
+    """Base Page Object which requires :class:`~.HttpResponse`
     and provides XPath / CSS shortcuts.
 
     Use this class as a base class for Page Objects which work on
     HTML downloaded using an HTTP client directly.
     """
-    response: ResponseData
+    response: HttpResponse
 
 
 @attr.s(auto_attribs=True)

--- a/web_poet/utils.py
+++ b/web_poet/utils.py
@@ -1,0 +1,17 @@
+import weakref
+from functools import wraps
+
+
+def memoizemethod_noargs(method):
+    """Decorator to cache the result of a method (without arguments) using a
+    weak reference to its object
+    """
+    cache = weakref.WeakKeyDictionary()
+
+    @wraps(method)
+    def new_method(self, *args, **kwargs):
+        if self not in cache:
+            cache[self] = method(self, *args, **kwargs)
+        return cache[self]
+
+    return new_method


### PR DESCRIPTION
This is https://github.com/scrapinghub/web-poet/pull/29 + https://github.com/scrapinghub/web-poet/pull/24, but sent against master branch, to ensure merging this doesn't depend on anything else.

TODO:

* [x] fix from-ground-up tutorial
* [x] double-check docs
* [x] tests for HttpResponse.css, xpath and selector
* [x] tests for HttpResponse.json
* [x] tests for HttpResponse.text and HttpResponse.encoding

Out o scope for this PR:
* implement HttpResponse.urljoin (can be done later)
* implement HttpResponse.base_url (can be done later)
* further clean-up of mixing (can be done later)
* clean-up of WebPage class?
* implement BrowserHtml (though we should do it before the release, as it might change code significantly)
* implement HttpRequestHeaders (though we should do it before the release, as it might change code significantly)