### PR TITLE
add from_bytes_dict alternative constructor for HttpResponseHeaders

### DIFF
--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -101,7 +101,8 @@ def test_http_response_headers_from_bytes_dict():
         b"Content-Encoding": [b"gzip", b"br"],
         b"server": b"sffe",
         "X-string": "string",
-        "X-missing": None
+        "X-missing": None,
+        "X-tuple": (b"x", "y"),
     }
     headers = HttpResponseHeaders.from_bytes_dict(raw_headers)
 
@@ -110,7 +111,18 @@ def test_http_response_headers_from_bytes_dict():
     assert headers.getall("Content-Encoding") == ["gzip", "br"]
     assert headers.get("server") == "sffe"
     assert headers.get("x-string") == "string"
-    assert headers.get("X-missing") is None
+    assert headers.get("x-missing") is None
+    assert headers.get("x-tuple") == "x"
+    assert headers.getall("x-tuple") == ["x", "y"]
+
+
+def test_http_response_headers_from_bytes_dict_err():
+
+    with pytest.raises(ValueError):
+        HttpResponseHeaders.from_bytes_dict({b"Content-Length": [316]})
+
+    with pytest.raises(ValueError):
+        HttpResponseHeaders.from_bytes_dict({b"Content-Length": 316})
 
 
 def test_http_response_headers_init_requests():

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -95,6 +95,24 @@ def test_http_respose_headers():
         headers["user agent"]
 
 
+def test_http_response_headers_from_bytes():
+    raw_headers = {
+        b"Content-Length": [b"316"],
+        b"Content-Encoding": [b"gzip", b"br"],
+        b"server": b"sffe",
+        "X-string": "string",
+        "X-missing": None
+    }
+    headers = HttpResponseHeaders.from_bytes(raw_headers)
+
+    assert headers.get("content-length") == "316"
+    assert headers.get("content-encoding") == "gzip"
+    assert headers.getall("Content-Encoding") == ["gzip", "br"]
+    assert headers.get("server") == "sffe"
+    assert headers.get("x-string") == "string"
+    assert headers.get("X-missing") is None
+
+
 def test_http_response_headers_init_requests():
     requests_response = requests.Response()
     requests_response.headers['User-Agent'] = "mozilla"

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -95,7 +95,7 @@ def test_http_respose_headers():
         headers["user agent"]
 
 
-def test_http_response_headers_from_bytes():
+def test_http_response_headers_from_bytes_dict():
     raw_headers = {
         b"Content-Length": [b"316"],
         b"Content-Encoding": [b"gzip", b"br"],
@@ -103,7 +103,7 @@ def test_http_response_headers_from_bytes():
         "X-string": "string",
         "X-missing": None
     }
-    headers = HttpResponseHeaders.from_bytes(raw_headers)
+    headers = HttpResponseHeaders.from_bytes_dict(raw_headers)
 
     assert headers.get("content-length") == "316"
     assert headers.get("content-encoding") == "gzip"

--- a/web_poet/page_inputs.py
+++ b/web_poet/page_inputs.py
@@ -76,7 +76,7 @@ class HttpResponseHeaders(CIMultiDict):
         return cls([(pair["name"], pair["value"]) for pair in arg])
 
     @classmethod
-    def from_bytes(
+    def from_bytes_dict(
         cls: Type[T_headers], arg: BytesDict, encoding: str = "utf-8"
     ) -> T_headers:
         """An alternative constructor for instantiation where the header-value
@@ -93,7 +93,7 @@ class HttpResponseHeaders(CIMultiDict):
         ...     b"Content-Type": [b"text/html"],
         ...     b"content-length": b"648",
         ... }
-        >>> headers = HttpResponseHeaders.from_bytes(raw_values)
+        >>> headers = HttpResponseHeaders.from_bytes_dict(raw_values)
         >>> headers
         <HttpResponseHeaders('Content-Encoding': 'gzip', 'Content-Encoding': 'br', 'Content-Type': 'text/html', 'content-length': '648')>
         """

--- a/web_poet/page_inputs.py
+++ b/web_poet/page_inputs.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional, Dict, List, TypeVar, Type
+from typing import Optional, Dict, List, TypeVar, Type, Union
 
 import attrs
 from multidict import CIMultiDict
@@ -14,6 +14,7 @@ from w3lib.encoding import (
 from .utils import memoizemethod_noargs
 
 T_headers = TypeVar("T_headers", bound="HttpResponseHeaders")
+BytesDict = Dict[bytes, Union[bytes, List[bytes]]]
 
 
 class HttpResponseBody(bytes):
@@ -73,6 +74,45 @@ class HttpResponseHeaders(CIMultiDict):
         <HttpResponseHeaders('Content-Encoding': 'gzip', 'content-length': '648')>
         """
         return cls([(pair["name"], pair["value"]) for pair in arg])
+
+    @classmethod
+    def from_bytes(
+        cls: Type[T_headers], arg: BytesDict, encoding: str = "utf-8"
+    ) -> T_headers:
+        """An alternative constructor for instantiation where the header-value
+        pairs are in raw bytes form.
+
+        This supports multiple header values in the form of ``List[bytes]``
+        alongside a plain ``bytes`` value.
+
+        By default, it converts the ``bytes`` value using "utf-8". However, this
+        can easily be overridden using the ``encoding`` parameter.
+
+        >>> raw_values = {
+        ...     b"Content-Encoding": [b"gzip", b"br"],
+        ...     b"Content-Type": [b"text/html"],
+        ...     b"content-length": b"648",
+        ... }
+        >>> headers = HttpResponseHeaders.from_bytes(raw_values)
+        >>> headers
+        <HttpResponseHeaders('Content-Encoding': 'gzip', 'Content-Encoding': 'br', 'Content-Type': 'text/html', 'content-length': '648')>
+        """
+
+        def _norm(data):
+            if isinstance(data, str):
+                return data
+            elif isinstance(data, bytes):
+                return data.decode(encoding)
+
+        converted = []
+
+        for header, value in arg.items():
+            if isinstance(value, list):
+                converted.extend([(_norm(header), _norm(v)) for v in value])
+            else:
+                converted.append((_norm(header), _norm(value)))
+
+        return cls(converted)
 
     def declared_encoding(self) -> Optional[str]:
         """ Return encoding detected from the Content-Type header, or None


### PR DESCRIPTION
From the recent enhancement in https://github.com/scrapinghub/web-poet/pull/30, it would seem that we'll need to support insantiating the `HttpResponseHeaders` from raw bytes values. In particular, frameworks like Scrapy uses header values in bytes format.

By default, https://github.com/aio-libs/multidict only supports strings and not bytes. Thus, an alternative constructor is proposed for ease of use.