### PR TITLE
Improve warning message for handle_urls

### DIFF
--- a/web_poet/overrides.py
+++ b/web_poet/overrides.py
@@ -156,8 +156,9 @@ class PageObjectRegistry(dict):
             else:
                 warnings.warn(
                     f"Multiple @handle_urls annotations with the same 'overrides' "
-                    f"are ignored in the same Registry. Ignoring duplicate "
-                    f"annotation on '{include}' for {cls}."
+                    f"are ignored in the same Registry. The following rule is "
+                    f"ignored:\n{rule}",
+                    stacklevel=2,
                 )
 
             return cls


### PR DESCRIPTION
Code which causes the warning (it's visible in web-poet testing suite):

```py
# This first annotation is ignored. A single annotation per registry is allowed
@handle_urls("example.com", overrides=POTopLevelOverriden1)
@handle_urls("example.com", overrides=POTopLevelOverriden1, exclude="/*.jpg|", priority=300)
class POTopLevel1(POBase):
    expected_overrides = POTopLevelOverriden1
    expected_patterns = Patterns(["example.com"], ["/*.jpg|"], priority=300)
    expected_meta = {}  # type: ignore

```


Current warning message:
```
web_poet/overrides.py:157
  /Users/kmike/svn/web-poet/web_poet/overrides.py:157: UserWarning: Multiple @handle_urls annotations with the same 'overrides' are ignored in the same Registry. Ignoring duplicate annotation on 'example.com' for <class 'tests.po_lib.POTopLevel1'>.
    warnings.warn(
```

Warning message in this PR:

```
tests/po_lib/__init__.py:29
  /Users/kmike/svn/web-poet/tests/po_lib/__init__.py:29: UserWarning: Multiple @handle_urls annotations with the same 'overrides' are ignored in the same Registry. The following rule is ignored:
  OverrideRule(for_patterns=Patterns(include=('example.com',), exclude=(), priority=500), use=<class 'tests.po_lib.POTopLevel1'>, instead_of=<class 'tests.po_lib.POTopLevelOverriden1'>, meta={})
    class POTopLevel1(POBase):
```

Changes:
* stacklevel argument is added so that the message points to the code which causes the warning, not to library internals
* the rule which is ignored is logged; I think previously it was unclear which rule out of 2 is ignored
* the message is changed a bit - "Ignoring duplicate annotation" was a bit ambiguous, because the rules (annotations) could be not duplicates, they're different in the example.