### PR TITLE
BrowserHtml

### DIFF
--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -4,6 +4,7 @@ import aiohttp.web_response
 import pytest
 import requests
 
+import parsel
 from web_poet.page_inputs import (
     HttpRequest,
     HttpResponse,
@@ -11,6 +12,7 @@ from web_poet.page_inputs import (
     HttpResponseBody,
     HttpRequestHeaders,
     HttpResponseHeaders,
+    BrowserHtml,
 )
 
 
@@ -421,3 +423,14 @@ def test_html5_meta_charset():
     response = HttpResponse("http://www.example.com", body=body)
     assert response.encoding == 'gb18030'
     assert response.text == body.decode('gb18030')
+
+
+def test_browser_html():
+    src = "<html><body><p>Hello, </p><p>world!</p></body></html>"
+    html = BrowserHtml(src)
+    assert html == src
+    assert html != "foo"
+
+    assert html.xpath("//p/text()").getall() == ["Hello, ", "world!"]
+    assert html.css("p::text").getall() == ["Hello, ", "world!"]
+    assert isinstance(html.selector, parsel.Selector)

--- a/web_poet/__init__.py
+++ b/web_poet/__init__.py
@@ -9,6 +9,7 @@ from .page_inputs import (
     HttpResponseHeaders,
     HttpRequestBody,
     HttpResponseBody,
+    BrowserHtml,
 )
 from .overrides import PageObjectRegistry, consume_modules, OverrideRule
 

--- a/web_poet/mixins.py
+++ b/web_poet/mixins.py
@@ -7,15 +7,14 @@ from w3lib.html import get_base_url
 
 class SelectableMixin(abc.ABC):
     """
-    Inherit from this mixin, implement ``.text`` property,
+    Inherit from this mixin, implement ``._selector_input`` method,
     get ``.selector`` property and ``.xpath`` / ``.css`` methods.
     """
     __cached_selector = None
 
-    @property
     @abc.abstractmethod
-    def text(self) -> str:
-        raise NotImplementedError()
+    def _selector_input(self) -> str:
+        raise NotImplementedError()  # pragma: nocover
 
     # XXX: see https://github.com/python/mypy/issues/1362
     @property   # type: ignore
@@ -26,7 +25,7 @@ class SelectableMixin(abc.ABC):
         if self.__cached_selector is not None:
             return self.__cached_selector
         # XXX: should we pass base_url=self.url, as Scrapy does?
-        sel = parsel.Selector(text=self.text)
+        sel = parsel.Selector(text=self._selector_input())
         self.__cached_selector = sel
         return sel
 
@@ -58,12 +57,9 @@ class ResponseShortcutsMixin(SelectableMixin):
     @property
     def html(self):
         """Shortcut to HTML Response's content."""
-        # required for backwards compatibility; todo: deprecate
         return self.response.text
 
-    @property
-    def text(self) -> str:
-        # required for SelectableMixin
+    def _selector_input(self) -> str:
         return self.html
 
     @property

--- a/web_poet/mixins.py
+++ b/web_poet/mixins.py
@@ -16,8 +16,7 @@ class SelectableMixin(abc.ABC):
     def _selector_input(self) -> str:
         raise NotImplementedError()  # pragma: nocover
 
-    # XXX: see https://github.com/python/mypy/issues/1362
-    @property   # type: ignore
+    @property
     def selector(self) -> parsel.Selector:
         """Cached instance of :external:class:`parsel.selector.Selector`."""
         # XXX: caching is implemented in a manual way to avoid issues with

--- a/web_poet/page_inputs/__init__.py
+++ b/web_poet/page_inputs/__init__.py
@@ -8,3 +8,4 @@ from .http import (
     HttpRequestBody,
     HttpResponseBody,
 )
+from .browser import BrowserHtml

--- a/web_poet/page_inputs/browser.py
+++ b/web_poet/page_inputs/browser.py
@@ -3,7 +3,7 @@ from web_poet.mixins import SelectableMixin
 
 class BrowserHtml(SelectableMixin, str):
     """ HTML returned by a web browser,
-    i.e. snapshot of the DOM tree in an HTML format.
+    i.e. snapshot of the DOM tree in HTML format.
     """
     def _selector_input(self) -> str:
         return self

--- a/web_poet/page_inputs/browser.py
+++ b/web_poet/page_inputs/browser.py
@@ -1,0 +1,10 @@
+from web_poet.mixins import SelectableMixin
+
+
+class BrowserHtml(str, SelectableMixin):
+    """ HTML returned by a web browser,
+    i.e. snapshot of the DOM tree in an HTML format.
+    """
+    def _selector_input(self) -> str:
+        return self
+

--- a/web_poet/page_inputs/browser.py
+++ b/web_poet/page_inputs/browser.py
@@ -1,7 +1,7 @@
 from web_poet.mixins import SelectableMixin
 
 
-class BrowserHtml(str, SelectableMixin):
+class BrowserHtml(SelectableMixin, str):
     """ HTML returned by a web browser,
     i.e. snapshot of the DOM tree in an HTML format.
     """

--- a/web_poet/page_inputs/http.py
+++ b/web_poet/page_inputs/http.py
@@ -213,6 +213,9 @@ class HttpResponse(SelectableMixin):
             self._cached_text = text
         return self._cached_text
 
+    def _selector_input(self) -> str:
+        return self.text
+
     @property
     def encoding(self):
         """ Encoding of the response """

--- a/web_poet/page_inputs/http.py
+++ b/web_poet/page_inputs/http.py
@@ -1,8 +1,7 @@
-import attrs
 import json
-import parsel
 from typing import Optional, Dict, List, Type, TypeVar, Union, Tuple, AnyStr
 
+import attrs
 from w3lib.encoding import (
     html_to_unicode,
     html_body_declared_encoding,
@@ -12,6 +11,7 @@ from w3lib.encoding import (
 
 from web_poet._base import _HttpHeaders
 from web_poet.utils import memoizemethod_noargs
+from web_poet.mixins import SelectableMixin
 
 T_headers = TypeVar("T_headers", bound="HttpResponseHeaders")
 
@@ -163,7 +163,7 @@ class HttpRequest:
 
 
 @attrs.define(auto_attribs=False, slots=False, eq=False)
-class HttpResponse:
+class HttpResponse(SelectableMixin):
     """A container for the contents of a response, downloaded directly using an
     HTTP client.
 
@@ -222,22 +222,6 @@ class HttpResponse:
             or self._body_declared_encoding()
             or self._body_inferred_encoding()
         )
-
-    # XXX: see https://github.com/python/mypy/issues/1362
-    @property   # type: ignore
-    @memoizemethod_noargs
-    def selector(self) -> parsel.Selector:
-        """Cached instance of :external:class:`parsel.selector.Selector`."""
-        # XXX: should we pass base_url=self.url, as Scrapy does?
-        return parsel.Selector(text=self.text)
-
-    def xpath(self, query, **kwargs):
-        """A shortcut to ``HttpResponse.selector.xpath()``."""
-        return self.selector.xpath(query, **kwargs)
-
-    def css(self, query):
-        """A shortcut to ``HttpResponse.selector.css()``."""
-        return self.selector.css(query)
 
     @memoizemethod_noargs
     def json(self):


### PR DESCRIPTION
In this PR url-less BrowserHtml is added. Unlike HttpResponseBody, its type is str, not bytes; this means selectors can be supported directly.

In autoextract-poet we had AutoextractHtml (https://github.com/scrapinghub/autoextract-poet/blob/aac08746c7ca9bc0baf07cfbf7773d616c26b1fb/autoextract_poet/page_inputs.py#L23), which is more similar to HttpResponse, as it contains URL.

I think we can add a similar class later, if needed. A design challenge would be to figure out wht should be a URL class - is the same as ResponseURL, or is it separate (BrowserURL) - assuming we're moving forward with https://github.com/scrapinghub/web-poet/pull/42.