### PR TITLE
request_backend_var -> request_downloader_var

### DIFF
--- a/docs/advanced/additional-requests.rst
+++ b/docs/advanced/additional-requests.rst
@@ -265,9 +265,9 @@ The key take aways for this example are:
       :external:py:class:`parsel.selector.Selector`; there are also
       :meth:`~.HttpResponse.css` and :meth:`~.HttpResponse.xpath` methods.
 
-        * Usually there's no need to use :meth:`~.HttpResponse.selector`,
-          as the :meth:`~.HttpResponse.css` and :meth:`~.HttpResponse.xpath`
-          are available.
+        * Usually there's no need to use :meth:`~.HttpResponse.selector`, as 
+          :meth:`~.HttpResponse.css` and :meth:`~.HttpResponse.xpath` are 
+          available.
 
 
 .. _`httpclient`:
@@ -372,7 +372,7 @@ There are a few things to take note in this example:
 
     * A ``GET`` request can be done via :class:`~.HttpClient`'s
       :meth:`~.HttpClient.get` method.
-    * There is no need to instantiate a :class:`~.HttpRequest` when
+    * There is no need create an instance of :class:`~.HttpRequest` when
       :meth:`~.HttpClient.get` is used.
 
 .. _`request-post-example`:
@@ -544,7 +544,7 @@ The key takeaways for this example are:
 
 .. tip::
 
-    The :meth:`~.HttpClient.batch_execute` method can multiple
+    The :meth:`~.HttpClient.batch_execute` method can execute multiple
     :class:`~.HttpRequest` instances. For example, it could be a mixture
     of ``GET`` and ``POST`` requests or even
     representing requests for various parts of the page altogether.
@@ -843,8 +843,8 @@ This can be set using:
 
     # Once this is set, the ``request_implementation`` becomes available to
     # all instances of HttpClient, unless HttpClient is created with
-    # ``request_downloader`` argument
-    # (see #2 Dependency Injection example below).
+    # the ``request_downloader`` argument (see the #2 Dependency Injection 
+    # example below).
     web_poet.request_downloader_var.set(request_implementation)
 
     # Assume that it's constructed with the necessary arguments taken somewhere.
@@ -858,7 +858,7 @@ When the ``web_poet.request_downloader_var`` contextvar is set,
 
 .. warning::
 
-    If no value for ``web_poet.request_downloader_var`` is set, then a
+    If no value for ``web_poet.request_downloader_var`` is set, then
     :class:`~.RequestDownloaderVarError` is raised. However, no exception is
     raised if **option 2** below is used.
 
@@ -866,7 +866,7 @@ When the ``web_poet.request_downloader_var`` contextvar is set,
 2. Dependency Injection
 ***********************
 
-The framework using **web-poet** may be using libraries which doesn't
+The framework using **web-poet** may be using libraries that don't
 have a full support to :mod:`contextvars` `(e.g. Twisted)`. With that, an
 alternative approach would be to supply the request downloader implementation
 when creating an :class:`~.HttpClient` instance:
@@ -897,9 +897,9 @@ when creating an :class:`~.HttpClient` instance:
     item = await page.to_item()
 
 From the code sample above, we can see that every time an :class:`~.HttpClient`
-is created for Page Objects needing an ``http_client``, framework must create
-:class:`~.HttpClient` with the specific **request downloader implementation**,
-using ``request_downloader`` argument.
+instance is created for Page Objects needing an ``http_client``, the framework 
+must create :class:`~.HttpClient` with a framework-specific **request 
+downloader implementation**, using the ``request_downloader`` argument.
 
 Downloader Behavior
 -------------------
@@ -932,8 +932,8 @@ Rationale
 *********
 
 Frameworks that handle **web-poet** MUST be able to ensure that Page Objects
-having additional requests using the :class:`~.HttpClient` are able to work
-with any type of HTTP downloader implementation.
+having additional requests using :class:`~.HttpClient` are able to work with 
+any type of HTTP downloader implementation.
 
 For example, in Python, the common HTTP libraries have different types of base
 exceptions when something has ocurred:

--- a/docs/advanced/additional-requests.rst
+++ b/docs/advanced/additional-requests.rst
@@ -122,8 +122,9 @@ HttpResponse
 :class:`~.HttpResponse` is what comes after a :class:`~.HttpRequest` has been
 executed. It's typically returned by the methods from :class:`~.HttpClient` (see
 :ref:`httpclient` tutorial section) which holds the information regarding the response.
-It's also the REQUIRED input for Page Objects inheriting from the :class:`~.ItemWebPage`
-class as explained from the :ref:`from-ground-up` tutorial.
+
+:class:`~.HttpResponse` can also be used as a Page Object dependency,
+e.g. :class:`~.WebPage` uses it.
 
 .. note::
 
@@ -260,13 +261,13 @@ The key take aways for this example are:
     * Since we now have an HTML response, using :meth:`~.HttpResponseBody.json`
       method would raise a ``JSONDecodeError`` as a JSON document cannot be
       parsed from it.
-    * The :meth:`~.HttpResponse.selector` property method returns an instance of
-      :external:py:class:`parsel.selector.Selector` which allows parsing via
-      :meth:`~.HttpResponse.css` and :meth:`~.HttpResponse.xpath` calls.
+    * The :meth:`~.HttpResponse.selector` property is an instance of
+      :external:py:class:`parsel.selector.Selector`; there are also
+      :meth:`~.HttpResponse.css` and :meth:`~.HttpResponse.xpath` methods.
 
-        * At the same time, there's no need to call :meth:`~.HttpResponse.selector`
-          each time as the :meth:`~.HttpResponse.css` and :meth:`~.HttpResponse.xpath`
-          are already conveniently available.
+        * Usually there's no need to use :meth:`~.HttpResponse.selector`,
+          as the :meth:`~.HttpResponse.css` and :meth:`~.HttpResponse.xpath`
+          are available.
 
 
 .. _`httpclient`:
@@ -304,7 +305,7 @@ Executing a HttpRequest instance
                 "product_id": self.css("#product ::attr(product-id)").get(),
             }
 
-            # Simulates clicking on a button that says "View All Images"
+            # Simulate clicking on a button that says "View All Images"
             request = web_poet.HttpRequest(f"https://api.example.com/v2/images?id={item['product_id']}")
             response: web_poet.HttpResponse = await self.http_client.execute(request)
 
@@ -371,8 +372,8 @@ There are a few things to take note in this example:
 
     * A ``GET`` request can be done via :class:`~.HttpClient`'s
       :meth:`~.HttpClient.get` method.
-    * There was no need to instantiate a :class:`~.HttpRequest` since :meth:`~.HttpClient.get`
-      already handles it before executing the request.
+    * There is no need to instantiate a :class:`~.HttpRequest` when
+      :meth:`~.HttpClient.get` is used.
 
 .. _`request-post-example`:
 
@@ -429,8 +430,8 @@ Thus, additional requests inside the Page Object are typically needed for it:
 Here's the key takeaway in this example:
 
     * Similar to :class:`~.HttpClient`'s :meth:`~.HttpClient.get` method,
-      a :meth:`~.HttpClient.post` method is also available that's
-      typically used to submit forms.
+      a :meth:`~.HttpClient.post` method is also available. It is
+      often used to submit forms.
 
 Other Single Requests
 ---------------------
@@ -447,12 +448,12 @@ quick shortcuts for :meth:`~.HttpClient.request`:
     body = b'{"data": "value"}'
 
     # These are the same:
-    client.get(url)
-    client.request(url, method="GET")
+    response = await client.get(url)
+    response = await client.request(url, method="GET")
 
     # The same goes for these:
-    client.post(url, headers=headers, body=body)
-    client.request(url, method="POST", headers=headers, body=body)
+    response = await client.post(url, headers=headers, body=body)
+    response = await client.request(url, method="POST", headers=headers, body=body)
 
 Thus, apart from the common ``GET`` and ``POST`` HTTP methods, you can use 
 :meth:`~.HttpClient.request` for them (`e.g.` ``HEAD``, ``PUT``, ``DELETE``, etc).
@@ -543,9 +544,9 @@ The key takeaways for this example are:
 
 .. tip::
 
-    The :meth:`~.HttpClient.batch_execute` method can accept different varieties
-    of :class:`~.HttpRequest` that MAY NOT be related with one another. For
-    example, it could be a mixture of ``GET`` and ``POST`` requests or even
+    The :meth:`~.HttpClient.batch_execute` method can multiple
+    :class:`~.HttpRequest` instances. For example, it could be a mixture
+    of ``GET`` and ``POST`` requests or even
     representing requests for various parts of the page altogether.
 
     Processing the additional requests in batch is useful since it takes advantage
@@ -567,8 +568,8 @@ The key takeaways for this example are:
 
 .. _`exception-handling`:
 
-Handling Exceptions in PO
-=========================
+Handling Exceptions in Page Objects
+===================================
 
 Let's have a look at how we could handle exceptions when performing additional
 requests inside Page Objects. For this example, let's improve the code snippet
@@ -643,7 +644,7 @@ behavior could be altered by using the ``allow_status`` param in the methods of
 
     In the future, more specific exceptions which inherits from the base
     :class:`web_poet.exceptions.http.HttpError` exception would be available.
-    This SHOULD enable developers writing Page Objects to properly identify what
+    This should allow developers writing Page Objects to properly identify what
     went wrong and act specifically based on the problem.
 
 Let's take another example when executing requests in batch as opposed to using
@@ -788,8 +789,8 @@ functionalities. However, as the docs have repeatedly mentioned, **web-poet**
 doesn't know how to execute any of these HTTP requests at all. It would be
 up to the framework that's handling **web-poet** to do so.
 
-In this section, we'll explore the guidelines for how frameworks MUST use
-**web-poet**. If you're a Page Object developer, you can skip this part as it
+In this section, we'll explore the guidelines for frameworks.
+If you're a Page Object developer, you can skip this part as it
 mostly discusses the internals. However, reading through this section could
 render a better understanding of **web-poet** as a whole.
 
@@ -798,7 +799,7 @@ render a better understanding of **web-poet** as a whole.
 Providing the Downloader 
 ------------------------
 
-Please note that on its own, :class:`~.HttpClient` doesn't do anything. It doesn't
+On its own, :class:`~.HttpClient` doesn't do anything. It doesn't
 know how to execute the request on its own. Thus, for frameworks or projects
 wanting to use additional requests in Page Objects, they need to set the
 implementation on how to execute an :class:`~.HttpRequest`.
@@ -865,7 +866,7 @@ When the ``web_poet.request_downloader_var`` contextvar is set,
 2. Dependency Injection
 ***********************
 
-The framework using **web-poet** MAY be using other libraries which doesn't
+The framework using **web-poet** may be using libraries which doesn't
 have a full support to :mod:`contextvars` `(e.g. Twisted)`. With that, an
 alternative approach would be to supply the request downloader implementation
 when creating an :class:`~.HttpClient` instance:
@@ -896,25 +897,26 @@ when creating an :class:`~.HttpClient` instance:
     item = await page.to_item()
 
 From the code sample above, we can see that every time an :class:`~.HttpClient`
-is created for Page Objects needing an ``http_client``, the specific **request
-implementation** from a given framework is injected to it.
+is created for Page Objects needing an ``http_client``, framework must create
+:class:`~.HttpClient` with the specific **request downloader implementation**,
+using ``request_downloader`` argument.
 
 Downloader Behavior
 -------------------
 
-The Downloader MUST be able to accept an instance of :class:`~.HttpRequest`
+The request downloader MUST accept an instance of :class:`~.HttpRequest`
 as the input and return an instance of :class:`~.HttpResponse`. This is important
 in order to handle and represent generic HTTP operations. The only time that
 it won't be returning :class:`~.HttpResponse` would be when it's raising exceptions
 (see :ref:`framework-exception-handling`).
 
-The Downloader MUST resolve Location-based **redirections** when the HTTP 
+The request downloader MUST resolve Location-based **redirections** when the HTTP
 method is not ``HEAD``. In other words, for non-``HEAD`` requests the 
 returned :class:`~.HttpResponse` must be the final response, after all redirects. 
 For ``HEAD`` requests redirects MUST NOT be resolved. 
 
-Lastly, the Downloader MUST support the ``async/await``
-syntax in order to enable developers to perform additional requests asynchronously.
+Lastly, the request downloader function MUST support the ``async/await``
+syntax.
 
 .. _framework-exception-handling:
 
@@ -930,8 +932,8 @@ Rationale
 *********
 
 Frameworks that handle **web-poet** MUST be able to ensure that Page Objects
-having additional requests using the :class:`~.HttpClient` is able to work in any
-type of HTTP downloader implementation.
+having additional requests using the :class:`~.HttpClient` are able to work
+with any type of HTTP downloader implementation.
 
 For example, in Python, the common HTTP libraries have different types of base
 exceptions when something has ocurred:
@@ -964,17 +966,17 @@ like the ones above, then it would cause the code to look like:
                 # handle the error here
 
 Such code could turn messy in no time especially when the number of HTTP backends
-that Page Objects SHOULD support are steadily increasing. Not to mention the 
+that Page Objects have to support are steadily increasing. Not to mention the
 plethora of exception types that HTTP libraries have. This means that Page
 Objects aren't truly portable in different types of frameworks or environments.
 Rather, they're only limited to work in the specific framework they're supported.
 
-In order for Page Objects to easily work in different Downloader Implementations,
-the framework that implements the HTTP Downloader backend MUST be able to raise
+In order for Page Objects to work in different Downloader Implementations,
+the framework that implements the HTTP Downloader backend MUST raise
 exceptions from the :mod:`web_poet.exceptions.http` module in lieu of the backend
 specific ones `(e.g. aiohttp, requests, urllib, etc.)`.
 
-This makes the code much simpler:
+This makes the code simpler:
 
 .. code-block:: python
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from web_poet.exceptions import HttpResponseError, RequestBackendError
+from web_poet.exceptions import HttpResponseError, RequestDownloaderVarError
 from web_poet.page_inputs import (
     HttpClient,
     HttpRequest,
@@ -10,7 +10,7 @@ from web_poet.page_inputs import (
     HttpRequestHeaders,
     HttpResponse,
 )
-from web_poet.requests import request_backend_var
+from web_poet.requests import request_downloader_var
 
 
 @pytest.fixture
@@ -31,10 +31,10 @@ async def test_perform_request_from_httpclient(async_mock):
     url = "http://example.com"
     client = HttpClient()
 
-    with pytest.raises(RequestBackendError):
+    with pytest.raises(RequestDownloaderVarError):
         await client.get(url)
 
-    request_backend_var.set(async_mock)
+    request_downloader_var.set(async_mock)
     response = await client.get(url)
 
     # The async downloader implementation should return the HttpResponse

--- a/web_poet/__init__.py
+++ b/web_poet/__init__.py
@@ -13,7 +13,7 @@ from .page_inputs import (
     ResponseUrl,
 )
 from .pages import Injectable, ItemPage, ItemWebPage, WebPage
-from .requests import request_backend_var
+from .requests import request_downloader_var
 
 default_registry = PageObjectRegistry()
 handle_urls = default_registry.handle_urls

--- a/web_poet/exceptions/core.py
+++ b/web_poet/exceptions/core.py
@@ -6,8 +6,8 @@ These exceptions are tied to how **web-poet** operates.
 """
 
 
-class RequestBackendError(Exception):
-    """The ``web_poet.request_backend_var`` had its contents accessed but there
+class RequestDownloaderVarError(Exception):
+    """The ``web_poet.request_downloader_var`` had its contents accessed but there
     wasn't any value set during the time requests are executed.
 
     See the documentation section about :ref:`setting up the contextvars <setup-contextvars>`

--- a/web_poet/page_inputs/client.py
+++ b/web_poet/page_inputs/client.py
@@ -36,13 +36,13 @@ class HttpClient:
     """A convenient client to easily execute requests.
 
     By default, it uses the request implementation assigned in the
-    ``web_poet.request_backend_var`` which is a :mod:`contextvars` instance to
+    ``web_poet.request_downloader_var`` which is a :mod:`contextvars` instance to
     download the actual requests. However, it can easily be overridable by
     providing an optional ``request_downloader`` callable.
 
     Providing the request implementation by dependency injection would be a good
     alternative solution when you want to avoid setting up :mod:`contextvars`
-    like ``web_poet.request_backend_var``.
+    like ``web_poet.request_downloader_var``.
 
     In any case, this doesn't contain any implementation about how to execute
     any requests fed into it. When setting that up, make sure that the downloader

--- a/web_poet/requests.py
+++ b/web_poet/requests.py
@@ -13,7 +13,7 @@ request_downloader_var: ContextVar = ContextVar("request_downloader")
 
 async def _perform_request(request: HttpRequest) -> HttpResponse:
     """Given a :class:`~.Request`, execute it using the **request implementation**
-    that was set in the ``web_poet.request_downloader`` :mod:`contextvars`
+    that was set in the ``web_poet.request_downloader_var`` :mod:`contextvars`
     instance.
     """
 

--- a/web_poet/requests.py
+++ b/web_poet/requests.py
@@ -1,38 +1,32 @@
 import logging
 from contextvars import ContextVar
 
-from web_poet.exceptions import RequestBackendError
+from web_poet.exceptions import RequestDownloaderVarError
 from web_poet.page_inputs.http import HttpRequest, HttpResponse
 
 logger = logging.getLogger(__name__)
 
 # Frameworks that wants to support additional requests in ``web-poet`` should
 # set the appropriate implementation for requesting data.
-request_backend_var: ContextVar = ContextVar("request_backend")
+request_downloader_var: ContextVar = ContextVar("request_downloader")
 
 
 async def _perform_request(request: HttpRequest) -> HttpResponse:
     """Given a :class:`~.Request`, execute it using the **request implementation**
-    that was set in the ``web_poet.request_backend_var`` :mod:`contextvars`
+    that was set in the ``web_poet.request_downloader`` :mod:`contextvars`
     instance.
-
-    .. warning::
-        By convention, this function should return a :class:`~.HttpResponse`.
-        However, the underlying downloader assigned in
-        ``web_poet.request_backend_var`` might change that, depending on
-        how the framework using **web-poet** implements it.
     """
 
     logger.info(f"Requesting page: {request}")
 
     try:
-        request_backend = request_backend_var.get()
+        request_downloader = request_downloader_var.get()
     except LookupError:
-        raise RequestBackendError(
+        raise RequestDownloaderVarError(
             "Additional requests are used inside the Page Object but the "
             "current framework has not set any HttpRequest Backend via "
-            "'web_poet.request_backend_var'"
+            "'web_poet.request_downloader_var'"
         )
 
-    response_data: HttpResponse = await request_backend(request)
+    response_data: HttpResponse = await request_downloader(request)
     return response_data


### PR DESCRIPTION
This is a backwards incompatible change. If we are to do it, we should do it as soon as possible.

When working on https://github.com/scrapinghub/web-poet/pull/50, I realized that HttpClient argument name is not consistent with the name of contextvar variable; argument name looks more clear.

There are also some minor changes / fixes to additional-requests docs, hope that's not an issue. I can make it a separate PR if needed.