### PR TITLE
New Retry exception

### DIFF
--- a/docs/advanced/additional-requests.rst
+++ b/docs/advanced/additional-requests.rst
@@ -1012,4 +1012,4 @@ the ``400-5xx`` range, **web-poet** raises the :class:`web_poet.exceptions.http.
 exception.
 
 From this distinction, the framework MUST NOT raise :class:`web_poet.exceptions.http.HttpResponseError`
-on its own at all, since the :class:`~.HttpClient` already handles that. 
+on its own at all, since the :class:`~.HttpClient` already handles that.

--- a/docs/advanced/retries.rst
+++ b/docs/advanced/retries.rst
@@ -4,14 +4,22 @@
 Retries
 =======
 
-The webpages of some websites can be unreliable. For example, sometimes
+The responses of some websites can be unreliable. For example, sometimes
 a request can get a response that may only include a part of the data to be
-extracted, or no data at all, but sending a follow-up, identical request can
-get you the expected data.
+extracted, no data at all, or even data unrelated to your request, but sending
+a follow-up, identical request can get you the expected data.
 
-You can write your page object so that it raises
-:exc:`~web_poet.exceptions.core.Retry` when it detects missing data that may become
-available after a request retry:
+Pages objects are responsible for handling these scenarios, where issues with
+response data can only be detected during extraction.
+
+.. _retries-input:
+
+Retrying Page Object Input
+==========================
+
+When the bad response data comes from the inputs that your web-poet framework
+supplies to your page object, your page object must raise
+:exc:`~web_poet.exceptions.core.Retry`:
 
 .. code-block:: python
 
@@ -20,13 +28,65 @@ available after a request retry:
 
     class MyPage(ItemWebPage):
 
-        def is_bad_response(self):
-            return not self.css('.expected-element')
-
         def to_item(self) -> dict:
-            if self.is_bad_response():
+            if not self.css('.expected'):
                 raise Retry
             return {}
+
+As a result, your web-poet framework will retry the source requests and create
+a new instance of your page object with the new inputs.
+
+
+.. _retries-additional-requests:
+
+Retrying Additional Requests
+============================
+
+When the bad response data comes from :ref:`additional requests
+<advanced-requests>`, you must handle retries on your own.
+
+The page object code is responsible for retrying additional requests until good
+response data is received, or until some maximum number of retries is exceeded.
+
+It is up to you to decide what the maximum number of retries should be for a
+given additional request, based on your experience with the target website.
+
+It is also up to you to decide how to implement retries of additional requests.
+
+One option would be tenacity_. For example, to try an additional request 3
+times before giving up:
+
+.. _tenacity: https://tenacity.readthedocs.io/en/latest/index.html
+
+.. code-block:: python
+
+    import attrs
+    from tenacity import retry, stop_after_attempt
+    from web_poet import HttpClient, HttpRequest, ItemWebPage
+
+    @attrs.define
+    class MyPage(ItemWebPage):
+        http_client: HttpClient
+
+        @retry(stop=stop_after_attempt(3))
+        async def get_data(self):
+            request = HttpRequest('https://toscrape.com/')
+            response = await self.http_client.execute(request)
+            if not response.css('.expected'):
+                raise ValueError
+            return response.css('.data').get()
+
+        async def to_item(self) -> dict:
+            try:
+                data = await self.get_data()
+            except ValueError:
+                return {}
+            return {'data': data}
+
+If the reason your additional request fails is outdated or missing data from
+page object input, do not try to reproduce the request for that input as an
+additional request. :ref:`Request fresh input instead <retries-input>`.
+
 
 .. _framework-retries:
 

--- a/docs/advanced/retries.rst
+++ b/docs/advanced/retries.rst
@@ -1,0 +1,57 @@
+.. _retries:
+
+=======
+Retries
+=======
+
+The webpages of some websites can be unreliable. For example, sometimes
+a request can get a response that may only include a part of the data to be
+extracted, or no data at all, but sending a follow-up, identical request can
+get you the expected data.
+
+You can write your page object so that it raises
+:exc:`~web_poet.exceptions.core.Retry` when it detects missing data that may become
+available after a request retry:
+
+.. code-block:: python
+
+    from web_poet import ItemWebPage
+    from web_poet.exceptions import Retry
+
+    class MyPage(ItemWebPage):
+
+        def is_bad_response(self):
+            return not self.css('.expected-element')
+
+        def to_item(self) -> dict:
+            if self.is_bad_response():
+                raise Retry
+            return {}
+
+.. _framework-retries:
+
+Framework Expectations
+======================
+
+Web-poet frameworks must catch :exc:`~web_poet.exceptions.core.Retry`
+exceptions raised from the :meth:`~web_poet.pages.ItemPage.to_item` method of a
+page object.
+
+When :exc:`~web_poet.exceptions.core.Retry` is caught:
+
+#.  The original request whose response was fed into the page object must be
+    retried.
+
+#.  A new page object must be created, of the same type as the original page
+    object, and with the same input, except for the response data, which must
+    be the new response.
+
+The :meth:`~web_poet.pages.ItemPage.to_item` method of the new page object may
+raise :exc:`~web_poet.exceptions.core.Retry` again. Web-poet frameworks must
+allow multiple retries of page objects, repeating the
+:exc:`~web_poet.exceptions.core.Retry`-capturing logic.
+
+However, web-poet frameworks are also encouraged to limit the amount of retries
+per page object. When retries are exceeded for a given page object, the page
+object output is ignored. At the moment, web-poet does not enforce any specific
+maximum number of retries on web-poet frameworks.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@ and the motivation behind ``web-poet``, start with :ref:`from-ground-up`.
    :caption: Advanced
    :maxdepth: 1
 
+   advanced/retries
    advanced/additional-requests
    advanced/page-params
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,8 +39,8 @@ and the motivation behind ``web-poet``, start with :ref:`from-ground-up`.
    :caption: Advanced
    :maxdepth: 1
 
-   advanced/retries
    advanced/additional-requests
+   advanced/retries
    advanced/page-params
 
 .. toctree::

--- a/web_poet/exceptions/core.py
+++ b/web_poet/exceptions/core.py
@@ -15,3 +15,13 @@ class RequestDownloaderVarError(Exception):
     """
 
     pass
+
+
+class Retry(ValueError):
+    """The page object found that the input data is partial or empty, and a
+    request retry may provide better input.
+
+    See :ref:`retries`.
+    """
+
+    pass


### PR DESCRIPTION
I think this is the direction that we want to go.

I was worrying at first about how this could impact additional requests, but then I realized that page objects can handle retries of additional requests on their own when those do not require first retrying the original request, and when they do, they can raise `Retry` to trigger that. Retries trigger a new page object, so they cannot keep state for additional request retries across original request retries, but that should not be a big issue.

It does feel like examples like https://web-poet.readthedocs.io/en/stable/intro/tutorial.html#final-result are becoming increasingly misleading, and I am starting to wonder if we should start providing some non-Scrapy reference framework implementation that better illustrates what the simplest web-poet framework could look like. But that is a separate topic.

No idea how to cover this change in tests.