### PR TITLE
Fields as properties

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -62,7 +62,8 @@ EXAMPLE_RESPONSE = HttpResponse(
 async def test_fields():
     page = Page(response=EXAMPLE_RESPONSE)
 
-    assert page.name() == "Hello!"
+    assert page.name == "Hello!"
+    assert await page.price == "$123"
 
     item = await page.to_item()
     assert isinstance(item, Item)
@@ -161,11 +162,11 @@ def test_field_cache_sync():
 
     pages = [Page("first"), Page("second")]
     for page in pages:
-        assert page.n_called_1() == (1, page.name)
-        assert page.n_called_1() == (1, page.name)
+        assert page.n_called_1 == (1, page.name)
+        assert page.n_called_1 == (1, page.name)
 
-        assert page.n_called_2() == (1, page.name)
-        assert page.n_called_2() == (2, page.name)
+        assert page.n_called_2 == (1, page.name)
+        assert page.n_called_2 == (2, page.name)
 
 
 @pytest.mark.asyncio
@@ -189,11 +190,11 @@ async def test_field_cache_async():
 
     pages = [Page("first"), Page("second")]
     for page in pages:
-        assert await page.n_called_1() == (1, page.name)
-        assert await page.n_called_1() == (1, page.name)
+        assert await page.n_called_1 == (1, page.name)
+        assert await page.n_called_1 == (1, page.name)
 
-        assert await page.n_called_2() == (1, page.name)
-        assert await page.n_called_2() == (2, page.name)
+        assert await page.n_called_2 == (1, page.name)
+        assert await page.n_called_2 == (2, page.name)
 
 
 @pytest.mark.asyncio
@@ -209,10 +210,10 @@ async def test_field_cache_async_locked():
 
     page = Page()
     results = await asyncio.gather(
-        page.n_called(),
-        page.n_called(),
-        page.n_called(),
-        page.n_called(),
-        page.n_called(),
+        page.n_called,
+        page.n_called,
+        page.n_called,
+        page.n_called,
+        page.n_called,
     )
     assert results == [1, 1, 1, 1, 1]

--- a/web_poet/fields.py
+++ b/web_poet/fields.py
@@ -25,18 +25,18 @@ It allows to define Page Objects in the following way:
 
 """
 from functools import update_wrapper
-from types import MethodType
 
 from web_poet.utils import cached_method, ensure_awaitable
 
 
 def field(method=None, *, cached=False):
     """
-    Page Object methods decorated with ``@field`` decorator
-    are called by :func:`item_from_fields` or :func:`item_from_fields_sync`
+    Page Object method decorated with ``@field`` decorator becomes a property,
+    which is used by :func:`item_from_fields` or :func:`item_from_fields_sync`
     to populate item attributes.
 
-    Use ``@field(cached=True)`` to cache the method result.
+    By default, the value is computed on each property access.
+    Use ``@field(cached=True)`` to cache the property value.
     """
 
     class _field:
@@ -55,7 +55,7 @@ def field(method=None, *, cached=False):
             owner._auto_item_fields[name] = True
 
         def __get__(self, instance, owner=None):
-            return MethodType(self.unbound_method, instance)
+            return self.unbound_method(instance)
 
     if method is not None:
         # @field syntax
@@ -78,4 +78,4 @@ async def item_from_fields(obj, item_cls=dict):
 def item_from_fields_sync(obj, item_cls=dict):
     """Synchronous version of :func:`item_from_fields`."""
     field_names = getattr(obj, "_auto_item_fields", {})
-    return item_cls(**{name: getattr(obj, name)() for name in field_names})
+    return item_cls(**{name: getattr(obj, name) for name in field_names})


### PR DESCRIPTION
The code changes turn out to be trivial :) 

It might be possible to simplify the implementation, and don't use cached_method to implement `field` decorator, but I'm not sure it worth it.

For properties there might be a stronger cause for making them cached by default. I'm worried about code like this:

```py
if page.name:
    item.product_name = page.name
```

Some features might be a bit harder to implement for properties later, e.g. exposing cache stats for cached properties or fields.