### PR TITLE
allow to store meta information about Page Object fields

### DIFF
--- a/docs/advanced/fields.rst
+++ b/docs/advanced/fields.rst
@@ -489,3 +489,31 @@ with async versions of ``@property`` and ``@cached_property`` decorators; unlike
 :func:`functools.lru_cache`, they all work fine for this use case.
 
 .. _async_property: https://github.com/ryananguiano/async_property
+
+Field metadata
+--------------
+
+web-poet allows to store arbitraty information for each field, using
+``meta`` keyword argument:
+
+.. code-block:: python
+
+    from web_poet import ItemPage, field
+
+    class MyPage(ItemPage):
+
+        @field(meta={"expensive": True})
+        async def my_field(self):
+            ...
+
+To retrieve this information, use :func:`web_poet.fields.get_fields_dict`; it
+returns a dictionary, where keys are field names, and values are
+:class:`web_poet.fields.FieldInfo` instances.
+
+.. code-block:: python
+
+    from web_poet.fields import get_fields_dict
+
+    fields_dict = get_fields_dict(MyPage)
+    field_names = fields_dict.keys()
+    my_field_meta = fields_dict["my_field"].meta

--- a/docs/advanced/fields.rst
+++ b/docs/advanced/fields.rst
@@ -493,7 +493,7 @@ with async versions of ``@property`` and ``@cached_property`` decorators; unlike
 Field metadata
 --------------
 
-web-poet allows to store arbitraty information for each field, using
+``web-poet`` allows to store arbitrary information for each field, using
 ``meta`` keyword argument:
 
 .. code-block:: python
@@ -517,3 +517,6 @@ returns a dictionary, where keys are field names, and values are
     fields_dict = get_fields_dict(MyPage)
     field_names = fields_dict.keys()
     my_field_meta = fields_dict["my_field"].meta
+    
+    print(field_names)  # dict_keys(['my_field'])
+    print(my_field_meta)  # {'expensive': True}

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -11,7 +11,7 @@ from web_poet import (
     item_from_fields,
     item_from_fields_sync,
 )
-from web_poet.fields import fields_dict
+from web_poet.fields import get_fields_dict
 
 
 @attrs.define
@@ -290,7 +290,7 @@ def test_field_meta():
             return item_from_fields_sync(self)
 
     page = MyPage()
-    for fields in [fields_dict(MyPage), fields_dict(page)]:
+    for fields in [get_fields_dict(MyPage), get_fields_dict(page)]:
         assert list(fields.keys()) == ["field1", "field2"]
         assert fields["field1"].name == "field1"
         assert fields["field1"].meta == {"good": True}

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -11,6 +11,7 @@ from web_poet import (
     item_from_fields,
     item_from_fields_sync,
 )
+from web_poet.fields import fields_dict
 
 
 @attrs.define
@@ -271,3 +272,26 @@ def test_item_cls_fields():
     page = ExtendedPage2(response=EXAMPLE_RESPONSE)
     item = page.to_item()
     assert item == Item(name="Hello!", price="$123")
+
+
+def test_field_meta():
+    class MyPage(ItemPage):
+        @field(meta={"good": True})
+        def field1(self):
+            return "foo"
+
+        @field
+        def field2(self):
+            return "foo"
+
+        def to_item(self):
+            return item_from_fields_sync(self)
+
+    page = MyPage()
+    for fields in [fields_dict(MyPage), fields_dict(page)]:
+        assert list(fields.keys()) == ["field1", "field2"]
+        assert fields["field1"].name == "field1"
+        assert fields["field1"].meta == {"good": True}
+
+        assert fields["field2"].name == "field2"
+        assert fields["field2"].meta is None

--- a/web_poet/fields.py
+++ b/web_poet/fields.py
@@ -50,9 +50,9 @@ def field(method=None, *, cached: bool = False, meta: Optional[dict] = None):
     By default, the value is computed on each property access.
     Use ``@field(cached=True)`` to cache the property value.
 
-    ``meta`` parameter allows to store arbitrary information for the
-    field - e.g. ``@field(meta={"expensive": True})``. This information
-    can be later retrieved for all fields using :func:`fields_dict` function.
+    The ``meta`` parameter allows to store arbitrary information for the field, 
+    e.g. ``@field(meta={"expensive": True})``. This information can be later 
+    retrieved for all fields using the :func:`fields_dict` function.
     """
 
     class _field:

--- a/web_poet/fields.py
+++ b/web_poet/fields.py
@@ -37,7 +37,12 @@ _FIELDS_INFO_ATTRIBUTE = "_web_poet_fields_info"
 
 @attrs.define
 class FieldInfo:
+    """Information about a field"""
+
+    #: name of the field
     name: str
+
+    #: field metadata
     meta: Optional[dict] = None
 
 
@@ -50,9 +55,9 @@ def field(method=None, *, cached: bool = False, meta: Optional[dict] = None):
     By default, the value is computed on each property access.
     Use ``@field(cached=True)`` to cache the property value.
 
-    The ``meta`` parameter allows to store arbitrary information for the field, 
-    e.g. ``@field(meta={"expensive": True})``. This information can be later 
-    retrieved for all fields using the :func:`fields_dict` function.
+    The ``meta`` parameter allows to store arbitrary information for the field,
+    e.g. ``@field(meta={"expensive": True})``. This information can be later
+    retrieved for all fields using the :func:`get_fields_dict` function.
     """
 
     class _field:
@@ -86,9 +91,11 @@ def field(method=None, *, cached: bool = False, meta: Optional[dict] = None):
         return _field
 
 
-def fields_dict(cls_or_instance) -> Dict[str, FieldInfo]:
+def get_fields_dict(cls_or_instance) -> Dict[str, FieldInfo]:
     """Return a dictionary with information about the fields defined
-    for the class"""
+    for the class: keys are field names, and values are
+    :class:`web_poet.fields.FieldInfo` instances.
+    """
     return getattr(cls_or_instance, _FIELDS_INFO_ATTRIBUTE, {})
 
 
@@ -112,7 +119,7 @@ async def item_from_fields(obj, item_cls=dict, *, item_cls_fields=False):
 
 def item_from_fields_sync(obj, item_cls=dict, *, item_cls_fields=False):
     """Synchronous version of :func:`item_from_fields`."""
-    field_names = list(fields_dict(obj))
+    field_names = list(get_fields_dict(obj))
     if item_cls_fields:
         field_names = _without_unsupported_field_names(item_cls, field_names)
     return item_cls(**{name: getattr(obj, name) for name in field_names})

--- a/web_poet/fields.py
+++ b/web_poet/fields.py
@@ -25,15 +25,23 @@ It allows to define Page Objects in the following way:
 
 """
 from functools import update_wrapper
+from typing import Dict, Optional
 
+import attrs
 from itemadapter import ItemAdapter
 
 from web_poet.utils import cached_method, ensure_awaitable
 
-_FIELDS_ATTRIBUTE = "_marked_as_fields"
+_FIELDS_INFO_ATTRIBUTE = "_web_poet_fields_info"
 
 
-def field(method=None, *, cached=False):
+@attrs.define
+class FieldInfo:
+    name: str
+    meta: Optional[dict] = None
+
+
+def field(method=None, *, cached: bool = False, meta: Optional[dict] = None):
     """
     Page Object method decorated with ``@field`` decorator becomes a property,
     which is used by :func:`item_from_fields` or :func:`item_from_fields_sync`
@@ -41,6 +49,10 @@ def field(method=None, *, cached=False):
 
     By default, the value is computed on each property access.
     Use ``@field(cached=True)`` to cache the property value.
+
+    ``meta`` parameter allows to store arbitrary information for the
+    field - e.g. ``@field(meta={"expensive": True})``. This information
+    can be later retrieved for all fields using :func:`fields_dict` function.
     """
 
     class _field:
@@ -53,10 +65,11 @@ def field(method=None, *, cached=False):
                 self.unbound_method = method
 
         def __set_name__(self, owner, name):
-            if not hasattr(owner, _FIELDS_ATTRIBUTE):
-                # dict is used instead of set to preserve the insertion order
-                setattr(owner, _FIELDS_ATTRIBUTE, {})
-            getattr(owner, _FIELDS_ATTRIBUTE)[name] = True
+            if not hasattr(owner, _FIELDS_INFO_ATTRIBUTE):
+                setattr(owner, _FIELDS_INFO_ATTRIBUTE, {})
+
+            field_info = FieldInfo(name=name, meta=meta)
+            getattr(owner, _FIELDS_INFO_ATTRIBUTE)[name] = field_info
 
         def __get__(self, instance, owner=None):
             return self.unbound_method(instance)
@@ -69,6 +82,12 @@ def field(method=None, *, cached=False):
     else:
         # @field(...) syntax
         return _field
+
+
+def fields_dict(cls_or_instance) -> Dict[str, FieldInfo]:
+    """Return a dictionary with information about the fields defined
+    for the class"""
+    return getattr(cls_or_instance, _FIELDS_INFO_ATTRIBUTE, {})
 
 
 async def item_from_fields(obj, item_cls=dict, *, item_cls_fields=False):
@@ -89,7 +108,7 @@ async def item_from_fields(obj, item_cls=dict, *, item_cls_fields=False):
 
 def item_from_fields_sync(obj, item_cls=dict, *, item_cls_fields=False):
     """Synchronous version of :func:`item_from_fields`."""
-    field_names = list(getattr(obj, _FIELDS_ATTRIBUTE, {}))
+    field_names = list(fields_dict(obj))
     if item_cls_fields:
         field_names = _without_unsupported_field_names(item_cls, field_names)
     return item_cls(**{name: getattr(obj, name) for name in field_names})


### PR DESCRIPTION
Motivation:

1. Allow custom extensions in third-party code, a point where additional information about a field can be stored
2. Introduce a structured FieldInfo, which can be used in other features