### PR TITLE
@field(extra=True)

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -11,6 +11,7 @@ from web_poet import (
     item_from_fields,
     item_from_fields_sync,
 )
+from web_poet.fields import fields_dict
 
 
 @attrs.define
@@ -271,3 +272,26 @@ def test_item_cls_fields():
     page = ExtendedPage2(response=EXAMPLE_RESPONSE)
     item = page.to_item()
     assert item == Item(name="Hello!", price="$123")
+
+
+def test_field_meta():
+    class MyPage(ItemPage):
+        @field(meta={"good": True})
+        def field1(self):
+            return "foo"
+
+        @field
+        def field2(self):
+            return "foo"
+
+        def to_item(self):
+            return item_from_fields_sync(self)
+
+    page = MyPage()
+    for fields in [fields_dict(MyPage), fields_dict(page)]:
+        assert list(fields.keys()) == ["field1", "field2"]
+        assert fields["field1"].name == "field1"
+        assert fields["field1"].meta == {"good": True}
+
+        assert fields["field2"].name == "field2"
+        assert fields["field2"].meta is None

--- a/web_poet/fields.py
+++ b/web_poet/fields.py
@@ -39,9 +39,10 @@ _FIELDS_INFO_ATTRIBUTE = "_web_poet_fields_info"
 class FieldInfo:
     name: str
     meta: Optional[dict] = None
+    extra: bool = False
 
 
-def field(method=None, *, cached: bool = False, meta: Optional[dict] = None):
+def field(method=None, *, cached: bool = False, meta: Optional[dict] = None, extra: bool = False):
     """
     Page Object method decorated with ``@field`` decorator becomes a property,
     which is used by :func:`item_from_fields` or :func:`item_from_fields_sync`
@@ -49,6 +50,10 @@ def field(method=None, *, cached: bool = False, meta: Optional[dict] = None):
 
     By default, the value is computed on each property access.
     Use ``@field(cached=True)`` to cache the property value.
+
+    Fields decorated with ``@field(extra=True)`` are not passed to item
+    classes by :func:`item_from_fields` if items don't support them, regardless
+    of ``item_cls_fields`` argument.
 
     ``meta`` parameter allows to store arbitrary information for the
     field - e.g. ``@field(meta={"expensive": True})``. This information
@@ -68,7 +73,7 @@ def field(method=None, *, cached: bool = False, meta: Optional[dict] = None):
             if not hasattr(owner, _FIELDS_INFO_ATTRIBUTE):
                 setattr(owner, _FIELDS_INFO_ATTRIBUTE, {})
 
-            field_info = FieldInfo(name=name, meta=meta)
+            field_info = FieldInfo(name=name, meta=meta, extra=extra)
             getattr(owner, _FIELDS_INFO_ATTRIBUTE)[name] = field_info
 
         def __get__(self, instance, owner=None):
@@ -96,22 +101,33 @@ async def item_from_fields(obj, item_cls=dict, *, item_cls_fields=False):
 
     If ``item_cls_fields`` is True, ``@fields`` whose names don't match
     any of the ``item_cls`` attributes are not passed to ``item_cls.__init__``.
+
     When ``item_cls_fields`` is False (default), all ``@fields`` are passed
-    to ``item_cls.__init__``.
+    to ``item_cls.__init__``, unless they're created with ``extra=True``
+    argument.
     """
-    item_dict = item_from_fields_sync(obj, item_cls=dict, item_cls_fields=False)
-    field_names = item_dict.keys()
-    if item_cls_fields:
-        field_names = _without_unsupported_field_names(item_cls, field_names)
+    field_names = _final_field_names(obj, item_cls, item_cls_fields)
+    item_dict = {name: getattr(obj, name) for name in field_names}
     return item_cls(**{name: await ensure_awaitable(item_dict[name]) for name in field_names})
 
 
 def item_from_fields_sync(obj, item_cls=dict, *, item_cls_fields=False):
     """Synchronous version of :func:`item_from_fields`."""
-    field_names = list(fields_dict(obj))
-    if item_cls_fields:
-        field_names = _without_unsupported_field_names(item_cls, field_names)
+    field_names = _final_field_names(obj, item_cls, item_cls_fields)
     return item_cls(**{name: getattr(obj, name) for name in field_names})
+
+
+def _final_field_names(obj, item_cls, item_cls_fields):
+    fields = fields_dict(obj)
+    extra_field_names = _without_unsupported_field_names(
+        item_cls, [info.name for info in fields.values() if info.extra]
+    )
+
+    regular_field_names = [info.name for info in fields.values() if not info.extra]
+    if item_cls_fields:
+        regular_field_names = _without_unsupported_field_names(item_cls, regular_field_names)
+
+    return regular_field_names + extra_field_names
 
 
 def _without_unsupported_field_names(item_cls, field_names):

--- a/web_poet/fields.py
+++ b/web_poet/fields.py
@@ -25,15 +25,23 @@ It allows to define Page Objects in the following way:
 
 """
 from functools import update_wrapper
+from typing import Dict, Optional
 
+import attrs
 from itemadapter import ItemAdapter
 
 from web_poet.utils import cached_method, ensure_awaitable
 
-_FIELDS_ATTRIBUTE = "_marked_as_fields"
+_FIELDS_INFO_ATTRIBUTE = "_web_poet_fields_info"
 
 
-def field(method=None, *, cached=False):
+@attrs.define
+class FieldInfo:
+    name: str
+    meta: Optional[dict] = None
+
+
+def field(method=None, *, cached: bool = False, meta: Optional[dict] = None):
     """
     Page Object method decorated with ``@field`` decorator becomes a property,
     which is used by :func:`item_from_fields` or :func:`item_from_fields_sync`
@@ -41,6 +49,10 @@ def field(method=None, *, cached=False):
 
     By default, the value is computed on each property access.
     Use ``@field(cached=True)`` to cache the property value.
+
+    ``meta`` parameter allows to store arbitrary information for the
+    field - e.g. ``@field(meta={"expensive": True})``. This information
+    can be later retrieved for all fields using :func:`fields_dict` function.
     """
 
     class _field:
@@ -53,10 +65,11 @@ def field(method=None, *, cached=False):
                 self.unbound_method = method
 
         def __set_name__(self, owner, name):
-            if not hasattr(owner, _FIELDS_ATTRIBUTE):
-                # dict is used instead of set to preserve the insertion order
-                setattr(owner, _FIELDS_ATTRIBUTE, {})
-            getattr(owner, _FIELDS_ATTRIBUTE)[name] = True
+            if not hasattr(owner, _FIELDS_INFO_ATTRIBUTE):
+                setattr(owner, _FIELDS_INFO_ATTRIBUTE, {})
+
+            field_info = FieldInfo(name=name, meta=meta)
+            getattr(owner, _FIELDS_INFO_ATTRIBUTE)[name] = field_info
 
         def __get__(self, instance, owner=None):
             return self.unbound_method(instance)
@@ -69,6 +82,12 @@ def field(method=None, *, cached=False):
     else:
         # @field(...) syntax
         return _field
+
+
+def fields_dict(cls_or_instance) -> Dict[str, FieldInfo]:
+    """Return a dictionary with information about the fields defined
+    for the class"""
+    return getattr(cls_or_instance, _FIELDS_INFO_ATTRIBUTE, {})
 
 
 async def item_from_fields(obj, item_cls=dict, *, item_cls_fields=False):
@@ -89,7 +108,7 @@ async def item_from_fields(obj, item_cls=dict, *, item_cls_fields=False):
 
 def item_from_fields_sync(obj, item_cls=dict, *, item_cls_fields=False):
     """Synchronous version of :func:`item_from_fields`."""
-    field_names = list(getattr(obj, _FIELDS_ATTRIBUTE, {}))
+    field_names = list(fields_dict(obj))
     if item_cls_fields:
         field_names = _without_unsupported_field_names(item_cls, field_names)
     return item_cls(**{name: getattr(obj, name) for name in field_names})


### PR DESCRIPTION
This feature allows to declare a field as `@field(extra=True)`. Such fields are ignored if the item type doesn't have them. It allows to define fields in the base class, which are not in the base item, and let items in subclasses use such fields.

```py
class FooPage(ItemPage):
    item_cls = StandardItem

    @field
    def standard_field1(self):
        return ...
   
     # .. all other fields   

    @field(extra=True)
    def non_standard_field(self):
        # this field is not in the StandardItem
        return ...

    def to_item(self):
        return item_from_fields_sync(self, self.item_cls)


@attrs.define
class ExtraItem(StandardItem):
    non_standard_field: Optional[str]


class CustomFooPage(FooPage):
    item_cls = ExtraItem
```

This PR is opened to get feedback. It partially addresses https://github.com/scrapinghub/web-poet/issues/59. But I don't like this approach (-1 to merge this PR); there are at least two issues with it:

1) FooPage now "knows" about `non_standard_field` attribute name, which is only defined in a non-standard item. 
2) It doesnt solve a problem of removing or renaming of the fields in subclasses, unless you define all fields as extra=True in the base class. Defining them all as extra=True defeats the purpose of having item_cls_fields=False as a default, as it disables all validation. 

To solve (1), one can avoid using fields, and use a regular method/property, though with more code:

```py
class FooPage(ItemPage):
    # ...
    def get_non_standard_field(self):
        # this field is not in the StandardItem
        return ...

class CustomFooPage(FooPage):
    item_cls = ExtraItem

    @field
    def non_standard_field(self):
        return self.get_non_standard_field()
```