### PR TITLE
Add support for field processors.

### DIFF
--- a/docs/advanced/fields.rst
+++ b/docs/advanced/fields.rst
@@ -151,6 +151,34 @@ function when accessing the fields:
 Now any field can be converted from sync to async, or the other way around,
 and the code would keep working.
 
+Field processors
+----------------
+
+It's often needed to clean or process field values using reusable functions.
+``@field`` takes an optional ``out`` argument with a list of such functions.
+They will be applied to the field value before returning it:
+
+.. code-block:: python
+
+    from web_poet import ItemPage, HttpResponse, field
+
+    def clean_tabs(s):
+        return s.replace('\t', ' ')
+
+    class MyPage(ItemPage):
+        response: HttpResponse
+
+        @field(out=[clean_tabs, str.strip])
+        def name(self):
+            return self.response.css(".name ::text").get()
+
+Note that while processors can be applied to async fields, they need to be
+normal functions themselves.
+
+It's also possible to implement field cleaning and processing in ``to_item``
+but in that case accessing a field directly will return the value without
+processing, so it's preferable to use field processors instead.
+
 Item classes
 ------------
 
@@ -197,9 +225,6 @@ but item classes are of a great help when
 
 * you need to extract data in the same format from multiple websites, or
 * if you want to define the schema upfront.
-
-Item classes can also be used to hold common attribute
-pre-processing and validation logic.
 
 Error prevention
 ~~~~~~~~~~~~~~~~
@@ -488,27 +513,3 @@ returns a dictionary, where keys are field names, and values are
 
     print(field_names)  # dict_keys(['my_field'])
     print(my_field_meta)  # {'expensive': True}
-
-Field processors
-----------------
-
-It's often needed to clean or process field values using reusable functions.
-``@field`` takes an optional ``out`` argument with a list of such functions.
-They will be applied to the field value before returning it:
-
-.. code-block:: python
-
-    from web_poet import ItemPage, HttpResponse, field
-
-    def clean_tabs(s):
-        return s.replace('\t', ' ')
-
-    class MyPage(ItemPage):
-        response: HttpResponse
-
-        @field(out=[clean_tabs, str.strip])
-        def name(self):
-            return self.response.css(".name ::text").get()
-
-Note that while processors can be applied to async fields, they need to be
-normal functions themselves.

--- a/docs/advanced/fields.rst
+++ b/docs/advanced/fields.rst
@@ -173,7 +173,7 @@ They will be applied to the field value before returning it:
             return self.response.css(".name ::text").get()
 
 Note that while processors can be applied to async fields, they need to be
-normal functions themselves.
+sync functions themselves.
 
 It's also possible to implement field cleaning and processing in ``to_item``
 but in that case accessing a field directly will return the value without

--- a/docs/advanced/fields.rst
+++ b/docs/advanced/fields.rst
@@ -488,3 +488,27 @@ returns a dictionary, where keys are field names, and values are
 
     print(field_names)  # dict_keys(['my_field'])
     print(my_field_meta)  # {'expensive': True}
+
+Field processors
+----------------
+
+It's often needed to clean or process field values using reusable functions.
+``@field`` takes an optional ``out`` argument with a list of such functions.
+They will be applied to the field value before returning it:
+
+.. code-block:: python
+
+    from web_poet import ItemPage, HttpResponse, field
+
+    def clean_tabs(s):
+        return s.replace('\t', ' ')
+
+    class MyPage(ItemPage):
+        response: HttpResponse
+
+        @field(out=[clean_tabs, str.strip])
+        def name(self):
+            return self.response.css(".name ::text").get()
+
+Note that while processors can be applied to async fields, they need to be
+normal functions themselves.

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -368,3 +368,32 @@ def test_field_with_other_decorators() -> None:
     assert page.field_foo == "foo"
     assert page.field_foo_meta == "foo"
     assert page.field_foo_cached == "foo"
+
+
+def test_field_processors_sync() -> None:
+    def proc1(s):
+        return s + "x"
+
+    @attrs.define
+    class Page(ItemPage):
+        @field(out=[str.strip, proc1])
+        def name(self):  # noqa: D102
+            return "  name\t "
+
+    page = Page()
+    assert page.name == "namex"
+
+
+@pytest.mark.asyncio
+async def test_field_processors_async() -> None:
+    def proc1(s):
+        return s + "x"
+
+    @attrs.define
+    class Page(ItemPage):
+        @field(out=[str.strip, proc1])
+        async def name(self):  # noqa: D102
+            return "  name\t "
+
+    page = Page()
+    assert await page.name == "namex"

--- a/web_poet/fields.py
+++ b/web_poet/fields.py
@@ -75,23 +75,23 @@ def field(
                 )
             if out:
                 orig_method = method
+
+                def _process(result):
+                    for processor in out:
+                        result = processor(result)
+                    return result
+
                 if inspect.iscoroutinefunction(method):
 
                     @wraps(method)
                     async def processed(*args, **kwargs):
-                        result = await orig_method(*args, **kwargs)
-                        for processor in out:
-                            result = processor(result)
-                        return result
+                        return _process(await orig_method(*args, **kwargs))
 
                 else:
 
                     @wraps(method)
                     def processed(*args, **kwargs):
-                        result = orig_method(*args, **kwargs)
-                        for processor in out:
-                            result = processor(result)
-                        return result
+                        return _process(orig_method(*args, **kwargs))
 
                 method = processed
 

--- a/web_poet/fields.py
+++ b/web_poet/fields.py
@@ -76,9 +76,7 @@ def field(
                 raise TypeError(
                     f"@field decorator must be used on methods, {method!r} is decorated instead"
                 )
-            if out:
-                method = self._processed(method)
-
+            method = self._processed(method)
             if cached:
                 self.unbound_method = cached_method(method)
             else:
@@ -102,6 +100,8 @@ def field(
 
         def _processed(self, method):
             """Returns a wrapper for method that calls processors on its result"""
+            if not out:
+                return method
             if inspect.iscoroutinefunction(method):
 
                 async def processed(*args, **kwargs):

--- a/web_poet/fields.py
+++ b/web_poet/fields.py
@@ -25,6 +25,9 @@ class FieldInfo:
     #: field metadata
     meta: Optional[dict] = None
 
+    #: field processors
+    out: Optional[List[Callable]] = None
+
 
 class FieldsMixin:
     """A mixin which is required for a class to support fields"""
@@ -104,7 +107,7 @@ def field(
             if not hasattr(owner, _FIELDS_INFO_ATTRIBUTE_WRITE):
                 setattr(owner, _FIELDS_INFO_ATTRIBUTE_WRITE, {})
 
-            field_info = FieldInfo(name=name, meta=meta)
+            field_info = FieldInfo(name=name, meta=meta, out=out)
             getattr(owner, _FIELDS_INFO_ATTRIBUTE_WRITE)[name] = field_info
 
         def __get__(self, instance, owner=None):


### PR DESCRIPTION
This adds support for an `out=` argument to `@field`, as proposed in https://github.com/zytedata/zyte-common-items/issues/18 (option 3). It only supports a list of callables, though it should be easy to also add support for a single callable. It only supports synchronous processors as async processors don't seem too useful and would change the signature of the field from sync to async which I find problematic.

I'm not sure how idiomatic (wrt both Python and web-poet) is the implementation but it's simple enough to be able to adjust it.