### PR TITLE
Documentation improvements for overrides (apply rules)

### DIFF
--- a/docs/intro/overrides.rst
+++ b/docs/intro/overrides.rst
@@ -69,10 +69,12 @@ URL rules. Some examples:
     # it contains "productId=..." in the query string
     @handle_urls("example.com?productId=*")
 
-Please consult with the url-matcher_ documentation for more; it is pretty
-flexible. It is possible to exclude patterns, use wildcards, require certain
-query parameters to be present and ignore others, etc.;
-unlike regexes, this mini-language "understands" the URL structure.
+The string passed to :func:`~.handle_urls` is converted to
+a :class:`url_matcher.matcher.Patterns` instance. Please consult
+with the url-matcher_ documentation to learn more about the possible rules;
+it is pretty flexible. You can exclude patterns, use wildcards,
+require certain query parameters to be present and ignore others, etc.
+Unlike regexes, this mini-language "understands" the URL structure.
 
 .. _url-matcher: https://url-matcher.readthedocs.io
 

--- a/docs/intro/overrides.rst
+++ b/docs/intro/overrides.rst
@@ -109,7 +109,7 @@ semantic markup, Machine Learning, heuristics, or just be empty. Page Objects wh
 can be used instead of the default (``Site1ProductPage``, ``Site2ProductPage``)
 are commonly written using XPath or CSS selectors, with website-specific rules.
 
-Libraries like scrapy-poet_ allows to create such "generic" spiders by
+Libraries like scrapy-poet_ allow to create such "generic" spiders by
 using the information declared via ``handle_urls(..., instead_of=...)``.
 
 Example Use Case

--- a/docs/intro/overrides.rst
+++ b/docs/intro/overrides.rst
@@ -30,7 +30,7 @@ declare how the page objects can be used (applied):
 getting the information about page objects programmatically.
 The information about all page objects decorated with
 :func:`~.handle_urls` is stored in ``web_poet.default_registry``, which is
-an instance of :class:`~.PageObjectRegistry`. In the example above the
+an instance of :class:`~.PageObjectRegistry`. In the example above, the
 following :class:`~.ApplyRule` is added to the registry:
 
 .. code-block::
@@ -39,7 +39,7 @@ following :class:`~.ApplyRule` is added to the registry:
         for_patterns=Patterns(include=('example.com',), exclude=(), priority=500),
         use=<class 'MyPage'>,
         instead_of=None,
-        to_return=<class 'MyItem'>,
+        to_return=<class 'my_items.MyItem'>,
         meta={}
     )
 
@@ -98,13 +98,13 @@ certain URL patterns:
         # ...
 
 This concept is a bit more advanced than the basic ``handle_urls`` usage
-("this Page Object can return MyItem on example.com website").
+("this Page Object can return ``MyItem`` on example.com website").
 
 A common use case is a "generic", or a "template" spider, which uses some
 default implementation of the extraction, and allows to replace it
 ("override") on specific websites or URL patterns.
 
-This default (``DefaultProductPage`` in the example) can be based on
+This default page extraction (``DefaultProductPage`` in the example) can be based on
 semantic markup, Machine Learning, heuristics, or just be empty. Page Objects which
 can be used instead of the default (``Site1ProductPage``, ``Site2ProductPage``)
 are commonly written using XPath or CSS selectors, with website-specific rules.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx==5.0.1
+Sphinx==5.3.0
 sphinx-rtd-theme==1.0.0

--- a/web_poet/rules.py
+++ b/web_poet/rules.py
@@ -40,61 +40,27 @@ class ApplyRule:
           pattern represented by the ``for_patterns`` attribute is matched.
         * ``instead_of`` - *(optional)* The Page Object that will be **replaced**
           with the Page Object specified via the ``use`` parameter.
-        * ``to_return`` - *(optional)* The item class that marks the Page Object
-          to be **used** which is capable of returning that item class.
+        * ``to_return`` - *(optional)* The item class which the **used**
+          Page Object is capable of returning.
         * ``meta`` - *(optional)* Any other information you may want to store.
           This doesn't do anything for now but may be useful for future API updates.
 
     The main functionality of this class lies in the ``instead_of`` and ``to_return``
     parameters. Should both of these be omitted, then :class:`~.ApplyRule` simply
     tags which URL patterns the given Page Object defined in ``use`` is expected
-    to be used. It works as:
+    to be used on.
 
-        1. Given a URL, match it against the ``for_patterns`` from the registry
-           rules.
-        2. This could give us a collection of rules. We need to select one based
-           on the highest priority set by `url-matcher`_.
-        3. When a single rule has been selected, use the the Page Object specified
-           in its ``use`` parameter.
+    When ``to_return`` is not None (e.g. ``to_return=MyItem``),
+    the Page Object in ``use`` is declared as capable of returning a certain
+    item class (``MyItem``).
 
-    If ``instead_of=None``, this simply means that the Page Object assigned in
-    the ``use`` parameter will be utilized for all URLs matching the URL pattern
-    in ``for_patterns``. However, if ``instead_of=ReplacedPageObject``, then it
-    adds the expectation that the ``ReplacedPageObject`` wouldn't be used for
-    the given URLs matching ``for_patterns`` since the Page Object in ``use``
-    will replace it. It works as:
+    When ``instead_of`` is not None (e.g. ``instead_of=ReplacedPageObject``),
+    the rule adds an expectation that the ``ReplacedPageObject`` wouldn't
+    be used for the URLs matching ``for_patterns``, since the Page Object
+    in ``use`` will replace it.
 
-        1. Suppose that we have a rule that has ``use=ReplacedPageObject`` which
-           we want to use against a URL that matches against ``for_patterns``.
-        2. Before using it, all of the rules from the registry must be checked if
-           other rules has ``instead_of=ReplacedPageObject`` and matches the
-           URL patterns in ``for_patterns``.
-        3. If there are, these rules supersedes the original rule from #1.
-        4. After selecting one based on the highest priority set by `url-matcher`_,
-           the Page Object declared in ``use`` should be used instead of
-           ``ReplacedPageObject``.
-
-    The ``to_return`` parameter should capture the item class that the Page Object
-    is capable of returning. Before passing it to :class:`~.ApplyRule`, the
-    ``to_return`` value is primarily derived from the return class specified
-    from Page Objects that are subclasses of :class:`~.ItemPage` (see this
-    :ref:`example <item-class-example>`). However, a special case exists when a
-    Page Object returns a ``dict`` as an item but then the rule should have
-    ``to_return=None`` and **NOT** ``to_return=dict``.
-
-    The ``to_return`` parameter is used as a shortcut to directly retrieve the
-    item from the Page Object to be used for a given URL. It works as:
-
-        1. Given a URL and and item class that we want, match it respectively
-           against ``for_patterns`` and ``to_return`` from the registry rules.
-        2. This could give us a collection of rules. We need to select one based
-           on the highest priority set by `url-matcher`_.
-        3. When a single rule has been selected, create an instance of the Page
-           Object specified in its ``use`` parameter.
-        4. Finally, call the ``.to_item()`` method of the Page Object to retrieve
-           an instance of the item class.
-
-    Using the ``to_return`` parameter basically adds the convenient step #4 above.
+    If there are multuple rules which match a certain URL, the rule
+    to apply is picked based on the priorities set in ``for_patterns``.
 
     More information regarding its usage in :ref:`intro-overrides`.
 

--- a/web_poet/rules.py
+++ b/web_poet/rules.py
@@ -41,7 +41,8 @@ class ApplyRule:
         * ``instead_of`` - *(optional)* The Page Object that will be **replaced**
           with the Page Object specified via the ``use`` parameter.
         * ``to_return`` - *(optional)* The item class which the **used**
-          Page Object is capable of returning.
+        * ``to_return`` - *(optional)* The item class that the Page Object specified
+          in ``use`` is capable of returning.
         * ``meta`` - *(optional)* Any other information you may want to store.
           This doesn't do anything for now but may be useful for future API updates.
 
@@ -52,14 +53,14 @@ class ApplyRule:
 
     When ``to_return`` is not None (e.g. ``to_return=MyItem``),
     the Page Object in ``use`` is declared as capable of returning a certain
-    item class (``MyItem``).
+    item class (i.e. ``MyItem``).
 
     When ``instead_of`` is not None (e.g. ``instead_of=ReplacedPageObject``),
     the rule adds an expectation that the ``ReplacedPageObject`` wouldn't
     be used for the URLs matching ``for_patterns``, since the Page Object
     in ``use`` will replace it.
 
-    If there are multuple rules which match a certain URL, the rule
+    If there are multiple rules which match a certain URL, the rule
     to apply is picked based on the priorities set in ``for_patterns``.
 
     More information regarding its usage in :ref:`intro-overrides`.


### PR DESCRIPTION
I've tried to simplify ApplyRule docstring, and also added an introduction for the Overrides (renamed to Apply Rules).

It seems overrides.rst might need a bit more cleanup (it became not very consistent after this PR, and it should be renamed to rules.rst), but I'd keep it out of scope for this PR.