### PR TITLE
update RulesRegistry to allow multiple rules in a single Page Object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,8 @@ Full list of changes:
 * ``PageObjectRegistry`` is replaced with ``RulesRegistry``; its API is changed:
 
     * **backwards incompatible** dict-like API is removed;
+    * **backwards incompatible** *O(1)* lookups using
+      ``.search(use=PagObject)`` has become *O(N)*;
     * ``search_overrides`` method is renamed to ``search``;
     * ``get_overrides`` method is renamed to ``get_rules``;
     * ``from_override_rules`` method is deprecated;

--- a/tests/po_lib/__init__.py
+++ b/tests/po_lib/__init__.py
@@ -1,7 +1,7 @@
 """
 This package is just for overrides testing purposes.
 """
-from typing import Any, Dict, Type
+from typing import Any, Dict, List, Type, Union
 
 from url_matcher import Patterns
 
@@ -12,7 +12,7 @@ from .. import po_lib_sub  # noqa: F401
 
 
 class POBase(ItemPage):
-    expected_instead_of: Type[ItemPage]
+    expected_instead_of: Union[Type[ItemPage], List[Type[ItemPage]]]
     expected_patterns: Patterns
     expected_to_return: Any = None
     expected_meta: Dict[str, Any]
@@ -26,17 +26,18 @@ class POTopLevelOverriden2(ItemPage):
     ...
 
 
-# This first decorator is ignored. A single ``ApplyRule`` with the same Page
-# Object to be used per registry is allowed.
 @handle_urls("example.com", instead_of=POTopLevelOverriden1)
 @handle_urls(
     "example.com", instead_of=POTopLevelOverriden1, exclude="/*.jpg|", priority=300
 )
 class POTopLevel1(POBase):
-    expected_instead_of = POTopLevelOverriden1
-    expected_patterns = Patterns(["example.com"], ["/*.jpg|"], priority=300)
-    expected_to_return = None
-    expected_meta = {}  # type: ignore
+    expected_instead_of = [POTopLevelOverriden1, POTopLevelOverriden1]
+    expected_patterns = [
+        Patterns(["example.com"], ["/*.jpg|"], priority=300),
+        Patterns(["example.com"]),
+    ]
+    expected_to_return = [None, None]
+    expected_meta = [{}, {}]  # type: ignore
 
 
 @handle_urls("example.com", instead_of=POTopLevelOverriden2)

--- a/web_poet/rules.py
+++ b/web_poet/rules.py
@@ -215,7 +215,7 @@ class RulesRegistry:
             beforehand to recursively import all submodules which contains the
             ``@handle_urls`` decorators from external Page Objects.
         """
-        return self._rules
+        return self._rules[:]
 
     def get_overrides(self) -> List[ApplyRule]:
         """Deprecated, use :meth:`~.RulesRegistry.get_rules` instead."""

--- a/web_poet/rules.py
+++ b/web_poet/rules.py
@@ -116,9 +116,9 @@ class RulesRegistry:
     """
 
     def __init__(self, *, rules: Optional[Iterable[ApplyRule]] = None):
-        self._page_object_rules: Dict[Type[ItemPage], ApplyRule] = {}
+        self._rules: List[ApplyRule] = []
         if rules is not None:
-            self._page_object_rules = {rule.use: rule for rule in rules}
+            self._rules = list(rules)
 
     @classmethod
     def from_override_rules(
@@ -200,17 +200,7 @@ class RulesRegistry:
                 to_return=to_return or get_item_cls(cls),
                 meta=kwargs,
             )
-            # If it was already defined, we don't want to override it
-            if cls not in self._page_object_rules:
-                self._page_object_rules[cls] = rule
-            else:
-                warnings.warn(
-                    f"Multiple @handle_urls decorators for the same Page Object "
-                    f"are ignored in the same Registry. The following rule is "
-                    f"ignored:\n{rule}",
-                    stacklevel=2,
-                )
-
+            self._rules.append(rule)
             return cls
 
         return wrapper
@@ -225,7 +215,7 @@ class RulesRegistry:
             beforehand to recursively import all submodules which contains the
             ``@handle_urls`` decorators from external Page Objects.
         """
-        return list(self._page_object_rules.values())
+        return self._rules
 
     def get_overrides(self) -> List[ApplyRule]:
         """Deprecated, use :meth:`~.RulesRegistry.get_rules` instead."""
@@ -247,14 +237,6 @@ class RulesRegistry:
             print(rules[0].instead_of)  # GenericPO
 
         """
-
-        # Short-circuit operation if "use" is the only search param used, since
-        # we know that it's being used as the dict key.
-        if {"use"} == kwargs.keys():
-            rule = self._page_object_rules.get(kwargs["use"])
-            if rule:
-                return [rule]
-            return []
 
         getter = attrgetter(*kwargs.keys())
 


### PR DESCRIPTION
Resolves https://github.com/scrapinghub/web-poet/issues/86.

Related to the prior work in https://github.com/scrapinghub/web-poet/pull/96.

This unblocks the WIP in https://github.com/scrapinghub/scrapy-poet/pull/88 when considering use cases that needs multiple rules in a single PO.

It's not necessary to include this in the `0.6.0` release.