### PR TITLE
Shorten the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,44 +22,31 @@ web-poet
    :target: https://web-poet.readthedocs.io/en/stable/?badge=stable
    :alt: Documentation Status
 
-``web-poet`` implements Page Object pattern for web scraping.
-It defines a standard for writing web data extraction code, which allows
-the code to be portable & reusable.
+.. intro starts
 
-License is BSD 3-clause.
+``web-poet`` is a Python 3.7+ implementation of the `page object pattern`_ for
+web scraping. It enables writing portable, reusable web data extraction code.
+
+.. _page object pattern: https://martinfowler.com/bliki/PageObject.html
+
+.. intro ends
+
+See the documentation_.
+
+.. _documentation: https://web-poet.readthedocs.io
 
 Installation
 ============
 
-::
+.. install starts
+
+To install web-poet, run:
+
+.. code-block:: bash
 
     pip install web-poet
 
-It requires Python 3.7+.
-
-Overview
-========
-
-web-poet is a library which defines a standard on how to write and organize
-web data extraction code.
-
-If web scraping code is written as web-poet Page Objects, it can be reused
-in different contexts. For example, such code can be developed in an
-`IPython notebook`_, then tested in isolation, and then plugged
-into a Scrapy_ spider, or used as a part of some custom aiohttp_-based
-web scraping framework.
-
-Currently, the following integrations are available:
-
-* Scrapy, via scrapy-poet_
-
-See Documentation_ for more.
-
-.. _scrapy-poet: https://github.com/scrapinghub/scrapy-poet
-.. _Documentation: https://web-poet.readthedocs.io
-.. _Scrapy: https://scrapy.org/
-.. _aiohttp: https://github.com/aio-libs/aiohttp
-.. _IPython notebook: https://jupyter.org/
+.. install ends
 
 
 Developing

--- a/docs/frameworks/additional-requests.rst
+++ b/docs/frameworks/additional-requests.rst
@@ -1,3 +1,4 @@
+.. _frameworks:
 .. _framework-additional-requests:
 
 ==============================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,26 +2,36 @@
 web-poet
 ========
 
-.. warning::
+.. warning:: web-poet is in early stages of development; backward-incompatible
+             changes are possible.
 
-    web-poet is in early stages of development; backwards incompatible
-    changes are possible.
+.. include:: ../README.rst
+   :start-after: intro starts
+   :end-before: intro ends
 
-``web-poet`` implements Page Object pattern for web scraping.
-It defines a standard for writing web data extraction code, which allows
-the code to be portable & reusable.
+web-poet provides :ref:`an API and best practices to write web data extraction
+code <page-objects>`, and :ref:`a specification to write implementations for
+that API <frameworks>`, like scrapy-poet_.
+
+.. _scrapy-poet: https://scrapy-poet.readthedocs.io
 
 The main idea is to separate the extraction logic from all other concerns.
 ``web-poet`` Page Objects `don't do I/O <https://sans-io.readthedocs.io>`_,
 and they're not dependent on any particular framework like Scrapy_.
 
-This allows the code written using ``web-poet`` to be testable and reusable.
-For example, one can write a web-poet Page Object in an IPython notebook,
-plug it into a Scrapy spider, write tests for them using unittest or pytest,
-and then reuse in a simple script which uses ``requests`` library.
+If web scraping code is written as web-poet Page Objects, it can be reused
+in different contexts. For example, such code can be developed in an
+`IPython notebook`_, then tested in isolation, and then plugged
+into a Scrapy_ spider, or used as a part of some custom aiohttp_-based
+web scraping framework.
 
-To install it, run ``pip install web-poet``. It requires Python 3.7+.
-:ref:`license` is BSD 3-clause.
+.. _aiohttp: https://github.com/aio-libs/aiohttp
+.. _IPython notebook: https://jupyter.org/
+.. _Scrapy: https://scrapy.org/
+
+.. include:: ../README.rst
+   :start-after: install starts
+   :end-before: install ends
 
 If you want to quickly learn how to write web-poet Page Objects,
 see :ref:`intro-tutorial`. To understand better all the ``web-poet`` concepts
@@ -59,8 +69,3 @@ and the motivation behind ``web-poet``, start with :ref:`from-ground-up`.
    contributing
    changelog
    license
-
-.. _web-poet: https://github.com/scrapinghub/web-poet
-.. _Scrapy: https://scrapy.org/
-.. _scrapy-poet: https://github.com/scrapinghub/scrapy-poet
-

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -1,4 +1,5 @@
 .. _intro-tutorial:
+.. _page-objects:
 
 =====================
 web-poet on a surface


### PR DESCRIPTION
Changes:
- Reword the introductory paragraph on the README:
  - Mention Python 3.7. It seems important to clarify early that this is Python-specific. By mentioning the minimum version here, we do not need to repeat that elsewhere either.
  - Provide an upstream link on the first mention of the page object pattern.
- Merge the “Overview” section of the README into index.rst, and provide the documentation link from the README right after the introductory paragraph.
  This minimizes the duplicate content from the user’s perspective. For users that read the README and then the documentation, duplicate information is now minimal.
- Use Sphinx’s `include` directive to include content from the README, to avoid duplicate content from a developer’s perspective.
- Removed mentions of the license from the README and index.rst. I think between GitHub, the LICENSE file and the corresponding documentation page, it is quite discoverable already.

Out of scope:
- Ideal locations for the new `page-objects` and `frameworks` reference IDs.
  For now these just link to the first page of the corresponding sections, but at some point we need a proper introductory topic for those sections, and when we have that, we need to move those reference IDs.
- Shortening index.rst.
  I think at some point index.rst should only need the the initial warning, the introductory paragraph from the README, and 1 or 2 more paragraphs that introduce with links some getting-started pages and the 2 main documentation sections. Everything else before the table of contents can probably move to some of those linked pages instead.
- Normalization of the capitalization of “page object”.
  But I must say that, after seeing how [Fowler’s post](https://martinfowler.com/bliki/PageObject.html) consistently uses lowercase, and how the (inconsistent) [Selenium documentation](https://www.selenium.dev/documentation/test_practices/encouraged/page_object_models/) favors lowercase as well, I feel even stronger in my position on this :)