### PR TITLE
Add SwitchPage

### DIFF
--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -57,7 +57,7 @@ Pages
 
 .. autoclass:: MultiLayoutPage
    :show-inheritance:
-   :members: layout
+   :members: get_layout
 
 Mixins
 ======

--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -55,6 +55,10 @@ Pages
    :show-inheritance:
    :members:
 
+.. autoclass:: MultiLayoutPage
+   :show-inheritance:
+   :members: layout
+
 Mixins
 ======
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ and the motivation behind ``web-poet``, start with :ref:`from-ground-up`.
    page-objects/additional-requests
    page-objects/fields
    page-objects/rules
+   Webpage layouts <page-objects/layouts>
    page-objects/retries
    page-objects/page-params
 

--- a/docs/page-objects/additional-requests.rst
+++ b/docs/page-objects/additional-requests.rst
@@ -1,4 +1,5 @@
 .. _advanced-requests:
+.. _page-objects:
 
 ===================
 Additional Requests

--- a/docs/page-objects/additional-requests.rst
+++ b/docs/page-objects/additional-requests.rst
@@ -1,5 +1,4 @@
 .. _advanced-requests:
-.. _page-objects:
 
 ===================
 Additional Requests

--- a/docs/page-objects/layouts.rst
+++ b/docs/page-objects/layouts.rst
@@ -185,8 +185,8 @@ Your multi-layout page object class should:
 
 You may use :class:`~web_poet.pages.MultiLayoutPage` as a base class for your
 multi-layout page object class, so you only need to implement the
-:class:`~web_poet.pages.MultiLayoutPage.layout` method that determines which
-page object to use. For example:
+:class:`~web_poet.pages.MultiLayoutPage.get_layout` method that determines
+which page object to use. For example:
 
 .. code-block:: python
 
@@ -222,7 +222,7 @@ page object to use. For example:
        h1: H1Page
        h2: H2Page
 
-       async def layout(self) -> ItemPage[Header]:
+       async def get_layout(self) -> ItemPage[Header]:
            if self.response.css("h1::text"):
                return self.h1
            return self.h2

--- a/docs/page-objects/layouts.rst
+++ b/docs/page-objects/layouts.rst
@@ -131,7 +131,6 @@ page object to use. For example:
     from web_poet import handle_urls, HttpResponse, ItemPage, MultiLayoutPage, WebPage
 
 
-    @attrs.define
     class Header:
         text: str
 

--- a/docs/page-objects/layouts.rst
+++ b/docs/page-objects/layouts.rst
@@ -74,6 +74,8 @@ When that is the case, you can :ref:`associate your page object class to the
 corresponding URL pattern <rules-intro>`.
 
 
+.. _switch:
+
 Switch page object classes
 --------------------------
 

--- a/docs/page-objects/layouts.rst
+++ b/docs/page-objects/layouts.rst
@@ -98,8 +98,11 @@ Your multi-layout page object class should:
     For example, declare an :class:`HttpResponse` attribute to select a page
     object class based on the response content.
 
-#.  Declare an attribute for every page object class that you may depending on
-    which webpage layout you get from the target website.
+#.  Declare an attribute for every page object class that you may use depending
+    on which webpage layout you get from the target website.
+
+    They all should return the same type of :ref:`item <item-classes>` as your
+    multi-layout page object class.
 
     Note that all inputs of all those page object classes will be resolved and
     requested along with the input of your multi-layout page object class. For
@@ -163,5 +166,5 @@ page object to use. For example:
 
 .. note:: If you use :func:`~web_poet.handle_urls` both for your multi-layout
           page object class and for any of the page object classes that it
-          uses, you may need to :ref:`grant your multi-layour page object class
+          uses, you may need to :ref:`grant your multi-layout page object class
           a higher priority <rules-priority-resolution>`.

--- a/docs/page-objects/layouts.rst
+++ b/docs/page-objects/layouts.rst
@@ -1,0 +1,152 @@
+.. _layouts:
+
+===============
+Webpage layouts
+===============
+
+Different webpages may show the same *type* of page, but different *data*. For
+example, in an e-commerce website there are usually many product detail pages,
+each showing data from a different product.
+
+The code that those webpages have in common is their **webpage layout**.
+
+Coding for webpage layouts
+==========================
+
+Webpage layouts should inform how you organize your data extraction code.
+
+A good practice to keep your code maintainable is to have a separate :ref:`page
+object class <page-objects>` per webpage layout.
+
+Trying to support multiple webpage layouts with the same page object class can
+make your class hard to maintain.
+
+
+Identifying webpage layouts
+===========================
+
+There is no precise way to determine whether 2 webpages have the same or a
+different webpage layout. You must decide based on what you know, and be ready
+to adapt if things change.
+
+It is also often difficult to identify webpage layouts before you start writing
+extraction code. Completely different webpage layouts can have the same look,
+and very similar webpage layouts can look completely different.
+
+It can be a good starting point to assume that, for a given combination of
+data type and website, there is going to be a single webpage layout. For
+example, assume that all product pages of a given e-commerce website will have
+the same webpage layout.
+
+Then, as you write a :ref:`page object class <page-objects>` for that webpage
+layout, you may find out more, and adapt.
+
+When the same piece of information must be extracted from a different place for
+different webpages, that is a sign that you may be dealing with more than 1
+webpage layout. For example, if on some webpages the product name is in an
+``h1`` element, but on some webpages it is in an ``h2`` element, chances are
+there are at least 2 different webpage layouts.
+
+However, whether you continue to work as if everything uses the same webpage
+layout, or you split your page object class into 2 page object classes, each
+targetting one of the webpage layouts you have found, it is entirely up to you.
+
+Ask yourself: Is supporting all webpage layout differences making your page
+object class implementation only a few lines of code longer, or is it making it
+an unmaintainable bowl of spagetti code?
+
+
+Mapping webpage layouts
+=======================
+
+Once you have written a :ref:`page object class <page-objects>` for a webpage
+layout, you need to make it so that your page object class is used for webpages
+that use that webpage layout.
+
+URL patterns
+------------
+
+Webpage layouts are often associated to specific URL patterns. For example, all
+the product detail pages of an e-commerce website usually have similar URLs,
+such as ``https://example.com/product/<product ID>``.
+
+When that is the case, you can :ref:`associate your page object class to the
+corresponding URL pattern <rules-intro>`.
+
+
+Switch page object classes
+--------------------------
+
+Sometimes it is impossible to know, based on the target URL, which webpage
+layout you are getting. For example, during `A/B testing`_, you could get a
+random webpage layout on every request.
+
+.. _A/B testing: https://en.wikipedia.org/wiki/A/B_testing
+
+For these scenarios, we recommend that you create a special “switch” page
+object class, and use it to switch to the right page object class at run time
+based on the input you receive.
+
+Your switch page object class should:
+
+#.  Request all the inputs that the candidate page object classes may need.
+
+    For example, if there are 2 candidate page object classes, and 1 of them
+    requires browser HTML as input, while the other one requires an HTTP
+    response, your switch page object class must request both.
+
+    If combining different inputs is a problem, consider refactoring the
+    candidate page object classes to require similar inputs.
+
+#.  On its :meth:`~web_poet.pages.ItemPage.to_item` method:
+
+    #.  Determine, based on the inputs, which candidate page object class to
+        use.
+
+    #.  Create an instance of the selected candidade page object class with the
+        necessary input, call its :meth:`~web_poet.pages.ItemPage.to_item`
+        method, and return its result.
+
+You may use :class:`~web_poet.pages.SwitchPage` as a base class for your switch
+page object class, so you only need to implement the
+:class:`~web_poet.pages.SwitchPage.switch` method that determines which
+candidate page object class to use. For example:
+
+.. code-block:: python
+
+    import attrs
+    from web_poet import handle_urls, HttpResponse, Injectable, ItemPage, SwitchPage
+
+
+    @attrs.define
+    class Header:
+        text: str
+
+
+    @attrs.define
+    class H1Page(ItemPage[Header]):
+        response: HttpResponse
+
+        @field
+        def text(self) -> str:
+            return self.response.css("h1::text").get()
+
+
+    @attrs.define
+    class H2Page(ItemPage[Header]):
+        response: HttpResponse
+
+        @field
+        def text(self) -> str:
+            return self.response.css("h2::text").get()
+
+
+    @handle_urls("example.com")
+    @attrs.define
+    class HeaderSwitchPage(SwitchPage[Header]):
+        response: HttpResponse
+
+        async def switch(self) -> Injectable:
+            if self.response.css("h1::text"):
+                return H1Page
+            return H2Page

--- a/docs/page-objects/layouts.rst
+++ b/docs/page-objects/layouts.rst
@@ -160,3 +160,8 @@ page object to use. For example:
             if self.response.css("h1::text"):
                 return self.h1
             return self.h2
+
+.. note:: If you use :func:`~web_poet.handle_urls` both for your multi-layout
+          page object class and for any of the page object classes that it
+          uses, you may need to :ref:`grant your multi-layour page object class
+          a higher priority <rules-priority-resolution>`.

--- a/tests/test_multilayout.py
+++ b/tests/test_multilayout.py
@@ -1,0 +1,116 @@
+"""Proof of concept of an approach to multi-layout support that involves
+documenting best practices on how to handle it with the existing API, rather
+than providing a new API for it."""
+
+import attrs
+import pytest
+
+from web_poet import HttpResponse, ItemPage, field
+
+
+@attrs.define
+class Item:
+    title: str
+    text: str
+
+
+@attrs.define
+class Title:
+    title: str
+
+
+@attrs.define
+class Text:
+    text: str
+
+
+@pytest.mark.asyncio
+async def test_multiple_inheritance():
+
+    html = b"""
+        <!doctype html>
+        <html>
+        <head>
+            <title>foo</title>
+        </head>
+            <text id="a">bar</text>
+        </html>
+    """
+
+    @attrs.define
+    class TitleAPage(ItemPage[Title]):
+        response: HttpResponse
+
+        @field
+        def title(self):
+            return self.response.css("title::text").get()
+
+    @attrs.define
+    class TitleBPage(ItemPage[Title]):
+        response: HttpResponse
+
+        @field
+        def title(self):
+            return self.response.css("h1::text").get()
+
+    @attrs.define
+    class TitleMultiLayout(ItemPage[Item]):
+        response: HttpResponse
+        title_a: TitleAPage
+        title_b: TitleBPage
+
+        # TODO: cache the result
+        def __get_layout(self):
+            if self.response.css("#a"):
+                return self.title_a
+            return self.title_b
+
+        @field
+        def title(self):
+            return self.__get_layout().title
+
+    @attrs.define
+    class TextAPage(ItemPage[Text]):
+        response: HttpResponse
+
+        @field
+        def text(self):
+            return self.response.css("#a::text").get()
+
+    @attrs.define
+    class TextBPage(ItemPage[Text]):
+        response: HttpResponse
+
+        @field
+        def text(self):
+            return self.response.css("#b::text").get()
+
+    @attrs.define
+    class TitleAndTextMultiLayout(TitleMultiLayout):
+        text_a: TextAPage
+        text_b: TextBPage
+
+        # TODO: cache the result
+        def __get_layout(self):
+            if self.response.css("#a"):
+                return self.text_a
+            return self.text_b
+
+        @field
+        def text(self):
+            return self.__get_layout().text
+
+    response = HttpResponse("https://example.com", body=html, encoding="utf8")
+    title_a = TitleAPage(response=response)
+    title_b = TitleBPage(response=response)
+    text_a = TextAPage(response=response)
+    text_b = TextBPage(response=response)
+    layout = TitleAndTextMultiLayout(
+        response=response,
+        title_a=title_a,
+        title_b=title_b,
+        text_a=text_a,
+        text_b=text_b,
+    )
+
+    assert await layout.to_item() == Item(title="foo", text="bar")

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -35,26 +35,22 @@ def test_page_object() -> None:
 
 
 @pytest.mark.asyncio
-async def test_switch_page_object():
+async def test_multi_layout_page_object():
     @attrs.define
     class Header:
         text: str
 
     @attrs.define
-    class H1Page(ItemPage[Header]):
-        response: HttpResponse
-
+    class H1Page(WebPage[Header]):
         @field
         def text(self) -> Optional[str]:
-            return self.response.css("h1::text").get()
+            return self.css("h1::text").get()
 
     @attrs.define
-    class H2Page(ItemPage[Header]):
-        response: HttpResponse
-
+    class H2Page(WebPage[Header]):
         @field
         def text(self) -> Optional[str]:
-            return self.response.css("h2::text").get()
+            return self.css("h2::text").get()
 
     @attrs.define
     class HeaderMultiLayoutPage(MultiLayoutPage[Header]):
@@ -62,7 +58,7 @@ async def test_switch_page_object():
         h1: H1Page
         h2: H2Page
 
-        async def switch(self) -> ItemPage[Header]:
+        async def layout(self) -> ItemPage[Header]:
             if self.response.css("h1::text"):
                 return self.h1
             return self.h2

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -40,13 +40,11 @@ async def test_multi_layout_page_object():
     class Header:
         text: str
 
-    @attrs.define
     class H1Page(WebPage[Header]):
         @field
         def text(self) -> Optional[str]:
             return self.css("h1::text").get()
 
-    @attrs.define
     class H2Page(WebPage[Header]):
         @field
         def text(self) -> Optional[str]:

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -56,7 +56,7 @@ async def test_multi_layout_page_object():
         h1: H1Page
         h2: H2Page
 
-        async def layout(self) -> ItemPage[Header]:
+        async def get_layout(self) -> ItemPage[Header]:
             if self.response.css("h1::text"):
                 return self.h1
             return self.h2
@@ -133,7 +133,7 @@ async def test_multi_layout_page_object_shared_partial_layout():
         page1: FullPage1
         page2: FullPage2
 
-        async def layout(self) -> ItemPage[FullItem]:
+        async def get_layout(self) -> ItemPage[FullItem]:
             if self.response.css("h1::text"):
                 return self.page1  # type: ignore[return-value]
             return self.page2  # type: ignore[return-value]
@@ -178,10 +178,10 @@ async def test_multi_layout_page_object_shared_partial_layout():
 
     # To access page object fields, you must first get the underlying page
     # object, and then access its fields:
-    layout1 = await multilayoutpage1.layout()
+    layout1 = await multilayoutpage1.get_layout()
     assert await layout1.url == url
     assert await layout1.text == "a"
-    layout2 = await multilayoutpage2.layout()
+    layout2 = await multilayoutpage2.get_layout()
     assert await layout2.url == url
     assert await layout2.text == "b"
 

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -98,6 +98,102 @@ async def test_multi_layout_page_object():
     assert item2.text == "b"
 
 
+@pytest.mark.asyncio
+async def test_multi_layout_page_object_shared_partial_layout():
+    """Scenario where a multi-layout page object acts as a switch for 2 or
+    more layout page objects that all inherit from some other page object class
+    that implements extraction for shared fields."""
+
+    @attrs.define
+    class PartialItem:
+        url: str
+
+    @attrs.define
+    class FullItem(PartialItem):
+        text: str
+
+    class PartialPage(WebPage[PartialItem]):
+        @field
+        async def url(self) -> str:
+            return str(self.response.url)
+
+    class FullPage1(PartialPage, Returns[FullItem]):
+        @field
+        async def text(self) -> Optional[str]:
+            return self.css("h1::text").get()
+
+    class FullPage2(PartialPage, Returns[FullItem]):
+        @field
+        async def text(self) -> Optional[str]:
+            return self.css("h2::text").get()
+
+    @attrs.define
+    class MyMultiLayoutPage(MultiLayoutPage[FullItem]):
+        response: HttpResponse
+        page1: FullPage1
+        page2: FullPage2
+
+        async def layout(self) -> ItemPage[FullItem]:
+            if self.response.css("h1::text"):
+                return self.page1  # type: ignore[return-value]
+            return self.page2  # type: ignore[return-value]
+
+    html1 = b"""
+    <!DOCTYPE html>
+    <html lang="en">
+        <head>
+            <title>h1</title>
+        </head>
+        <body>
+            <h1>a</h1>
+        </body>
+    </html>
+    """
+    html2 = b"""
+    <!DOCTYPE html>
+    <html lang="en">
+        <head>
+            <title>h2</title>
+        </head>
+        <body>
+            <h2>b</h2>
+        </body>
+    </html>
+    """
+
+    url = "https://example.com"
+    response1 = HttpResponse(url, body=html1)
+    page1_1 = FullPage1(response=response1)
+    page2_1 = FullPage2(response=response1)
+    response2 = HttpResponse(url, body=html2)
+    page1_2 = FullPage1(response=response2)
+    page2_2 = FullPage2(response=response2)
+
+    multilayoutpage1 = MyMultiLayoutPage(
+        response=response1, page1=page1_1, page2=page2_1
+    )
+    multilayoutpage2 = MyMultiLayoutPage(
+        response=response2, page1=page1_2, page2=page2_2
+    )
+
+    # To access page object fields, you must first get the underlying page
+    # object, and then access its fields:
+    layout1 = await multilayoutpage1.layout()
+    assert await layout1.url == url
+    assert await layout1.text == "a"
+    layout2 = await multilayoutpage2.layout()
+    assert await layout2.url == url
+    assert await layout2.text == "b"
+
+    # Returned items work as expected.
+    item1 = await multilayoutpage1.to_item()
+    assert item1.url == url
+    assert item1.text == "a"
+    item2 = await multilayoutpage2.to_item()
+    assert item2.url == url
+    assert item2.text == "b"
+
+
 def test_web_page_object(book_list_html_response) -> None:
     class MyWebPage(WebPage):
         def to_item(self) -> dict:  # type: ignore

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py311,mypy,docs,types
+envlist = py37,py38,py39,py310,py311,mypy,docs,types,linters
 
 [pytest]
 asyncio_mode = strict

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -75,7 +75,7 @@ class MultiLayoutPage(ItemPage[ItemT]):
     """
 
     @abc.abstractmethod
-    async def layout(self) -> ItemPage[ItemT]:
+    async def get_layout(self) -> ItemPage[ItemT]:
         """Return the :ref:`page object <page-objects>` to use based on the
         received input (e.g. :class:`~.HttpResponse`)."""
 
@@ -83,7 +83,7 @@ class MultiLayoutPage(ItemPage[ItemT]):
         """Return the output of the :meth:`~web_poet.pages.ItemPage.to_item`
         method of the :ref:`page object <page-objects>` that :meth:`layout`
         returns."""
-        page_object = await self.layout()
+        page_object = await self.get_layout()
         return await page_object.to_item()
 
 

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -68,6 +68,28 @@ class ItemPage(Injectable, Returns[ItemT]):
         )
 
 
+class SwitchPage(Injectable, Returns[ItemT]):
+    """Base class for :ref:`switch page object classes <switch>`.
+
+    Subclasses must reimplement the :meth:`switch` method.
+    """
+
+    @abc.abstractmethod
+    async def switch(self) ->  Injectable:
+        """Return the right :ref:`page object class <page-objects>` based on
+        the received input."""
+        raise NotImplementedError
+
+    async def to_item(self) -> ItemT:
+        """Create an instance of the class that :meth:`switch` returns with the
+        required input, and return the output of its
+        :meth:`~web_poet.pages.ItemPage.to_item` method."""
+        page_object_class = await self.switch()
+        # page_object = page_object_class(...)  # TODO: pass the right inputs
+        page_object = page_object_class(response=self.response)
+        return await page_object.to_item()
+
+
 @attr.s(auto_attribs=True)
 class WebPage(ItemPage[ItemT], ResponseShortcutsMixin):
     """Base Page Object which requires :class:`~.HttpResponse`

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -77,7 +77,7 @@ class MultiLayoutPage(ItemPage[ItemT]):
     @abc.abstractmethod
     async def layout(self) -> ItemPage[ItemT]:
         """Return the :ref:`page object <page-objects>` to use based on the
-        received input."""
+        received input (e.g. :class:`~.HttpResponse`)."""
 
     async def to_item(self) -> ItemT:
         """Return the output of the :meth:`~web_poet.pages.ItemPage.to_item`

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -69,22 +69,22 @@ class ItemPage(Injectable, Returns[ItemT]):
 
 
 class MultiLayoutPage(ItemPage[ItemT]):
-    """Base class for :ref:`switch page object classes <switch>`.
+    """Base class for :ref:`multi-layout page object classes <multi-layout>`.
 
-    Subclasses must reimplement the :meth:`switch` method.
+    Subclasses must reimplement the :meth:`layout` method.
     """
 
     @abc.abstractmethod
-    async def switch(self) -> ItemPage[ItemT]:
-        """Return the right :ref:`page object class <page-objects>` based on
-        the received input."""
+    async def layout(self) -> ItemPage[ItemT]:
+        """Return the :ref:`page object <page-objects>` to use based on the
+        received input."""
         raise NotImplementedError
 
     async def to_item(self) -> ItemT:
-        """Create an instance of the class that :meth:`switch` returns with the
-        required input, and return the output of its
-        :meth:`~web_poet.pages.ItemPage.to_item` method."""
-        page_object = await self.switch()
+        """Return the output of the :meth:`~web_poet.pages.ItemPage.to_item`
+        method of the :ref:`page object <page-objects>` that :meth:`layout`
+        returns."""
+        page_object = await self.layout()
         return await page_object.to_item()
 
 

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -78,7 +78,6 @@ class MultiLayoutPage(ItemPage[ItemT]):
     async def layout(self) -> ItemPage[ItemT]:
         """Return the :ref:`page object <page-objects>` to use based on the
         received input."""
-        raise NotImplementedError
 
     async def to_item(self) -> ItemT:
         """Return the output of the :meth:`~web_poet.pages.ItemPage.to_item`

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -68,14 +68,14 @@ class ItemPage(Injectable, Returns[ItemT]):
         )
 
 
-class SwitchPage(Injectable, Returns[ItemT]):
+class MultiLayoutPage(ItemPage[ItemT]):
     """Base class for :ref:`switch page object classes <switch>`.
 
     Subclasses must reimplement the :meth:`switch` method.
     """
 
     @abc.abstractmethod
-    async def switch(self) ->  Injectable:
+    async def switch(self) -> ItemPage[ItemT]:
         """Return the right :ref:`page object class <page-objects>` based on
         the received input."""
         raise NotImplementedError
@@ -84,9 +84,7 @@ class SwitchPage(Injectable, Returns[ItemT]):
         """Create an instance of the class that :meth:`switch` returns with the
         required input, and return the output of its
         :meth:`~web_poet.pages.ItemPage.to_item` method."""
-        page_object_class = await self.switch()
-        # page_object = page_object_class(...)  # TODO: pass the right inputs
-        page_object = page_object_class(response=self.response)
+        page_object = await self.switch()
         return await page_object.to_item()
 
 


### PR DESCRIPTION
Changes:
- Implement a `SwitchPage` class, that can be subclassed to create special page object classes that call other page object classes based on the received input.
- New documentation page about webpage layouts as a web scraping concept, to provide context before introducing the new class.
  It took me a while to write it in a way that did not presume too much prior knowledge from the reader, and I am still unhappy with the result, so I would love some feedback here.

Arguments for the proposed API:
- I think the code that determines which page object class to use should be centralized (`switch` method in the current proposal), as opposed to defining it on each page object class. Otherwise, handling priorities and corner cases could become cumbersome.
- In regards to the eventual implementation of a mechanism to detect invalid layouts, I do not see a problem. Assuming that we implement it by raising some special exception, such an exception could be raised from `switch` if no right page object class is found, or from the `to_item` method of the selected page object class if, despite that page object class getting selected from `switch`, the input it gets does not match some other expectation.
- For cases where different candidate page object classes have different inputs, the documentation asks for the switch page object class to be declared with a combination of all of them, and then the right ones would be fed into the selected page object class (to be implemented; I assume it is feasible, but I would like some input on how to approach it).

To do:
- [x] Discuss the proposed API.
    - [ ] ~~Do we need to have some override mechanism for candidate page object classes? i.e. Does there need to be a way through rules to replace a candidate page object class instead of replacing the whole switch page object class?~~ (out of scope)
- [x] ~~Implement input passing to the selected candidate page object class (andi? inspect and simple type matching?).~~ (layout page object classes are now declared as inputs, letting web-poet frameworks handle this automatically through dependency injection)
- [x] ~~Provide a nice exception if there is a missing input?~~ (not relevant given the resolution of the bullet point above)