### PR TITLE
Serialization support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,9 @@
 [flake8]
 ignore =
+    # Refers to "whitespace before ':'", which black produces.
+    # https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#slices
+    E203,
+
     # Refers to the max-line length. Let's suppress the error and simply
     # let black take care on how it wants to format the lines.
     E501,

--- a/.flake8
+++ b/.flake8
@@ -37,4 +37,5 @@ per-file-ignores =
     # D102: Missing docstring in public method
     web_poet/__init__.py:F401,F403
     web_poet/page_inputs/__init__.py:F401,F403
-    tests/po_lib_to_return/__init__.py:D102 
+    web_poet/serialization/__init__.py:F401,F403
+    tests/po_lib_to_return/__init__.py:D102

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "w3lib >= 1.22.0",
         "async-lru >= 1.0.3",
         "itemadapter >= 0.7.0",
+        "andi",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from web_poet.page_inputs import HttpResponse, HttpResponseBody, ResponseUrl
+from web_poet.page_inputs import HttpResponse, HttpResponseBody
 
 
 def read_fixture(path):
@@ -20,7 +20,5 @@ def book_list_html():
 def book_list_html_response(book_list_html):
     body = HttpResponseBody(bytes(book_list_html, "utf-8"))
     return HttpResponse(
-        url=ResponseUrl("http://books.toscrape.com/index.html"),
-        body=body,
-        encoding="utf-8",
+        url="http://books.toscrape.com/index.html", body=body, encoding="utf-8"
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from web_poet.page_inputs import HttpResponse, HttpResponseBody
+from web_poet.page_inputs import HttpResponse, HttpResponseBody, ResponseUrl
 
 
 def read_fixture(path):
@@ -20,5 +20,7 @@ def book_list_html():
 def book_list_html_response(book_list_html):
     body = HttpResponseBody(bytes(book_list_html, "utf-8"))
     return HttpResponse(
-        url="http://books.toscrape.com/index.html", body=body, encoding="utf-8"
+        url=ResponseUrl("http://books.toscrape.com/index.html"),
+        body=body,
+        encoding="utf-8",
     )

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -22,15 +22,15 @@ from web_poet.serialization import (
 )
 
 
-def _compare_webpages(p1: WebPage, p2: WebPage) -> None:
+def _assert_webpages_equal(p1: WebPage, p2: WebPage) -> None:
     assert p1.response.body == p2.response.body
     assert p1.response.status == p2.response.status
     assert p1.response.headers == p2.response.headers
     assert p1.response._encoding == p2.response._encoding
-    _compare_urls(p1.response.url, p2.response.url)
+    _assert_urls_equal(p1.response.url, p2.response.url)
 
 
-def _compare_urls(u1: _Url, u2: _Url) -> None:
+def _assert_urls_equal(u1: _Url, u2: _Url) -> None:
     assert type(u1) == type(u2)
     assert str(u1) == str(u2)
 
@@ -54,10 +54,10 @@ def test_serialization_unsup() -> None:
 
 
 def test_serialization_webpage(book_list_html_response) -> None:
-    po = WebPage(book_list_html_response)
+    po: WebPage = WebPage(book_list_html_response)
     serialized_po = serialize(po)
     deserialized_po = deserialize(WebPage, serialized_po)
-    _compare_webpages(po, deserialized_po)
+    _assert_webpages_equal(po, deserialized_po)
 
 
 def test_serialization_httpresponse_encoding(book_list_html) -> None:
@@ -127,7 +127,7 @@ def test_custom_functions() -> None:
     assert obj.value == deserialized_obj.value
 
 
-def test_extra_attrs():
+def test_extra_attrs() -> None:
     @attrs.define
     class C(Injectable):
         f1: Optional[str]
@@ -144,11 +144,11 @@ def test_extra_attrs():
 def test_write_data(book_list_html_response, tmp_path) -> None:
     directory = tmp_path / "ser"
     directory.mkdir()
-    po = WebPage(book_list_html_response)
+    po: WebPage = WebPage(book_list_html_response)
     serialized_po = serialize(po)
     write_serialized_data(serialized_po, directory)
     assert (directory / "response.body.html").exists()
     read_serialized_po = read_serialized_data(directory)
     deserialized_po = deserialize(WebPage, read_serialized_po)
     assert type(deserialized_po) == WebPage
-    _compare_webpages(po, deserialized_po)
+    _assert_webpages_equal(po, deserialized_po)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -60,12 +60,17 @@ def test_serialization(book_list_html_response) -> None:
     url = ResponseUrl(url_str)
 
     serialized_deps = serialize([book_list_html_response, url])
-    assert serialized_deps["HttpResponse"]["body.html"] == bytes(
-        book_list_html_response.body
+    assert serialized_deps["web_poet.page_inputs.http.HttpResponse"][
+        "body.html"
+    ] == bytes(book_list_html_response.body)
+    other_data = json.loads(
+        serialized_deps["web_poet.page_inputs.http.HttpResponse"]["other.json"]
     )
-    other_data = json.loads(serialized_deps["HttpResponse"]["other.json"])
     assert other_data["url"] == url_str
-    assert serialized_deps["ResponseUrl"]["txt"] == url_str.encode()
+    assert (
+        serialized_deps["web_poet.page_inputs.url.ResponseUrl"]["txt"]
+        == url_str.encode()
+    )
 
     po = MyWebPage(book_list_html_response, url)
     deserialized_po = deserialize(MyWebPage, serialized_deps)
@@ -122,13 +127,13 @@ def test_write_data(book_list_html_response, tmp_path) -> None:
     directory.mkdir()
     serialized_deps = serialize([book_list_html_response, url])
     write_serialized_data(serialized_deps, directory)
-    assert (directory / "HttpResponse-body.html").exists()
-    assert (directory / "HttpResponse-body.html").read_bytes() == bytes(
-        book_list_html_response.body
-    )
-    assert (directory / "HttpResponse-other.json").exists()
-    assert (directory / "ResponseUrl.txt").exists()
-    assert (directory / "ResponseUrl.txt").read_text(
+    assert (directory / "web_poet.page_inputs.http.HttpResponse-body.html").exists()
+    assert (
+        directory / "web_poet.page_inputs.http.HttpResponse-body.html"
+    ).read_bytes() == bytes(book_list_html_response.body)
+    assert (directory / "web_poet.page_inputs.http.HttpResponse-other.json").exists()
+    assert (directory / "web_poet.page_inputs.url.ResponseUrl.txt").exists()
+    assert (directory / "web_poet.page_inputs.url.ResponseUrl.txt").read_text(
         encoding="utf-8"
     ) == "http://example.com"
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,23 +1,18 @@
-from typing import Optional, Type
+from typing import Type
 
 import attrs
 import pytest
 
-from web_poet import (
-    HttpResponse,
-    HttpResponseBody,
-    Injectable,
-    RequestUrl,
-    ResponseUrl,
-    WebPage,
-)
+from web_poet import HttpResponse, HttpResponseBody, ResponseUrl, WebPage
 from web_poet.page_inputs.url import _Url
 from web_poet.serialization import (
-    SerializedData,
+    SerializedLeafData,
     deserialize,
+    deserialize_leaf,
     read_serialized_data,
     register_serialization,
     serialize,
+    serialize_leaf,
     write_serialized_data,
 )
 
@@ -35,28 +30,34 @@ def _assert_urls_equal(u1: _Url, u2: _Url) -> None:
     assert str(u1) == str(u2)
 
 
-def test_serialization() -> None:
+def test_serialization_leaf() -> None:
     data = {"a": "b", "c": 42}
-    serialized_data = serialize(data)
-    deserialized_data = deserialize(dict, serialized_data)
+    serialized_data = serialize_leaf(data)
+    deserialized_data = deserialize_leaf(dict, serialized_data)
     assert data == deserialized_data
 
 
-def test_serialization_unsup() -> None:
+def test_serialization_leaf_unsup() -> None:
     class A:
         pass
 
     with pytest.raises(NotImplementedError):
-        serialize(A())
+        serialize_leaf(A())
 
     with pytest.raises(NotImplementedError):
-        deserialize(A, {})
+        deserialize_leaf(A, {})
 
 
-def test_serialization_webpage(book_list_html_response) -> None:
-    po: WebPage = WebPage(book_list_html_response)
-    serialized_po = serialize(po)
-    deserialized_po = deserialize(WebPage, serialized_po)
+def test_serialization(book_list_html_response) -> None:
+    @attrs.define
+    class MyWebPage(WebPage):
+        url: ResponseUrl
+
+    url = ResponseUrl("http://example.com")
+
+    serialized_deps = serialize([book_list_html_response, url])
+    po = MyWebPage(book_list_html_response, url)
+    deserialized_po = deserialize(MyWebPage, serialized_deps)
     _assert_webpages_equal(po, deserialized_po)
 
 
@@ -68,43 +69,15 @@ def test_serialization_httpresponse_encoding(book_list_html) -> None:
         encoding="utf-8",
     )
     assert resp_enc._encoding == "utf-8"
-    deserialized_resp_enc = deserialize(HttpResponse, serialize(resp_enc))
+    deserialized_resp_enc = deserialize_leaf(HttpResponse, serialize_leaf(resp_enc))
     assert deserialized_resp_enc._encoding == "utf-8"
 
     resp_noenc = HttpResponse(
         url=ResponseUrl("http://books.toscrape.com/index.html"), body=body
     )
     assert resp_noenc._encoding is None
-    deserialized_resp_noenc = deserialize(HttpResponse, serialize(resp_noenc))
+    deserialized_resp_noenc = deserialize_leaf(HttpResponse, serialize_leaf(resp_noenc))
     assert deserialized_resp_noenc._encoding is None
-
-
-def test_serialization_misc_types(book_list_html_response) -> None:
-    @attrs.define
-    class MyWebPage(WebPage):
-        f1: str
-        f2: bytes
-        f3: RequestUrl
-        f4: Optional[str]
-        f5: Optional[str]
-
-    po = MyWebPage(
-        response=book_list_html_response,
-        f1="foo",
-        f2=b"bar",
-        f3=RequestUrl("http://example.com"),
-        f4=None,
-        f5="baz",
-    )
-    serialized_po = serialize(po)
-    deserialized_po = deserialize(MyWebPage, serialized_po)
-    assert type(deserialized_po) == MyWebPage
-    assert deserialized_po.f1 == "foo"
-    assert deserialized_po.f2 == b"bar"
-    assert type(deserialized_po.f3) == RequestUrl
-    assert str(deserialized_po.f3) == "http://example.com"
-    assert deserialized_po.f4 is None
-    assert deserialized_po.f5 == "baz"
 
 
 def test_custom_functions() -> None:
@@ -114,41 +87,33 @@ def test_custom_functions() -> None:
         def __init__(self, value: int):
             self.value = value
 
-    def _serialize(o: C) -> SerializedData:
+    def _serialize(o: C) -> SerializedLeafData:
         return {"bin": o.value.to_bytes((o.value.bit_length() + 7) // 8, "little")}
 
-    def _deserialize(t: Type[C], data: SerializedData) -> C:
+    def _deserialize(t: Type[C], data: SerializedLeafData) -> C:
         return t(int.from_bytes(data["bin"], "little"))
 
     register_serialization(_serialize, _deserialize)
 
     obj = C(22222222222)
-    deserialized_obj = deserialize(C, serialize(obj))
+    deserialized_obj = deserialize_leaf(C, serialize_leaf(obj))
     assert obj.value == deserialized_obj.value
 
 
-def test_extra_attrs() -> None:
-    @attrs.define
-    class C(Injectable):
-        f1: Optional[str]
-        f2: Optional[str]
-
-    obj = C(f1="foo", f2="bar")
-    serialized_obj = serialize(obj)
-    del serialized_obj["f1"]
-    deserialized_obj = deserialize(C, serialized_obj)
-    assert deserialized_obj.f1 is None
-    assert deserialized_obj.f2 == "bar"
-
-
 def test_write_data(book_list_html_response, tmp_path) -> None:
+    @attrs.define
+    class MyWebPage(WebPage):
+        url: ResponseUrl
+
+    url = ResponseUrl("http://example.com")
+
     directory = tmp_path / "ser"
     directory.mkdir()
-    po: WebPage = WebPage(book_list_html_response)
-    serialized_po = serialize(po)
-    write_serialized_data(serialized_po, directory)
-    assert (directory / "response.body.html").exists()
-    read_serialized_po = read_serialized_data(directory)
-    deserialized_po = deserialize(WebPage, read_serialized_po)
-    assert type(deserialized_po) == WebPage
+    serialized_deps = serialize([book_list_html_response, url])
+    write_serialized_data(serialized_deps, directory)
+    assert (directory / "HttpResponse-body.html").exists()
+    read_serialized_deps = read_serialized_data(directory)
+    po = MyWebPage(book_list_html_response, url)
+    deserialized_po = deserialize(MyWebPage, read_serialized_deps)
+    assert type(deserialized_po) == MyWebPage
     _assert_webpages_equal(po, deserialized_po)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,154 @@
+from typing import Optional, Type
+
+import attrs
+import pytest
+
+from web_poet import (
+    HttpResponse,
+    HttpResponseBody,
+    Injectable,
+    RequestUrl,
+    ResponseUrl,
+    WebPage,
+)
+from web_poet.page_inputs.url import _Url
+from web_poet.serialization import (
+    SerializedData,
+    deserialize,
+    read_serialized_data,
+    register_serialization,
+    serialize,
+    write_serialized_data,
+)
+
+
+def _compare_webpages(p1: WebPage, p2: WebPage) -> None:
+    assert p1.response.body == p2.response.body
+    assert p1.response.status == p2.response.status
+    assert p1.response.headers == p2.response.headers
+    assert p1.response._encoding == p2.response._encoding
+    _compare_urls(p1.response.url, p2.response.url)
+
+
+def _compare_urls(u1: _Url, u2: _Url) -> None:
+    assert type(u1) == type(u2)
+    assert str(u1) == str(u2)
+
+
+def test_serialization() -> None:
+    data = {"a": "b", "c": 42}
+    serialized_data = serialize(data)
+    deserialized_data = deserialize(dict, serialized_data)
+    assert data == deserialized_data
+
+
+def test_serialization_unsup() -> None:
+    class A:
+        pass
+
+    with pytest.raises(NotImplementedError):
+        serialize(A())
+
+    with pytest.raises(NotImplementedError):
+        deserialize(A, {})
+
+
+def test_serialization_webpage(book_list_html_response) -> None:
+    po = WebPage(book_list_html_response)
+    serialized_po = serialize(po)
+    deserialized_po = deserialize(WebPage, serialized_po)
+    _compare_webpages(po, deserialized_po)
+
+
+def test_serialization_httpresponse_encoding(book_list_html) -> None:
+    body = HttpResponseBody(bytes(book_list_html, "utf-8"))
+    resp_enc = HttpResponse(
+        url=ResponseUrl("http://books.toscrape.com/index.html"),
+        body=body,
+        encoding="utf-8",
+    )
+    assert resp_enc._encoding == "utf-8"
+    deserialized_resp_enc = deserialize(HttpResponse, serialize(resp_enc))
+    assert deserialized_resp_enc._encoding == "utf-8"
+
+    resp_noenc = HttpResponse(
+        url=ResponseUrl("http://books.toscrape.com/index.html"), body=body
+    )
+    assert resp_noenc._encoding is None
+    deserialized_resp_noenc = deserialize(HttpResponse, serialize(resp_noenc))
+    assert deserialized_resp_noenc._encoding is None
+
+
+def test_serialization_misc_types(book_list_html_response) -> None:
+    @attrs.define
+    class MyWebPage(WebPage):
+        f1: str
+        f2: bytes
+        f3: RequestUrl
+        f4: Optional[str]
+        f5: Optional[str]
+
+    po = MyWebPage(
+        response=book_list_html_response,
+        f1="foo",
+        f2=b"bar",
+        f3=RequestUrl("http://example.com"),
+        f4=None,
+        f5="baz",
+    )
+    serialized_po = serialize(po)
+    deserialized_po = deserialize(MyWebPage, serialized_po)
+    assert type(deserialized_po) == MyWebPage
+    assert deserialized_po.f1 == "foo"
+    assert deserialized_po.f2 == b"bar"
+    assert type(deserialized_po.f3) == RequestUrl
+    assert str(deserialized_po.f3) == "http://example.com"
+    assert deserialized_po.f4 is None
+    assert deserialized_po.f5 == "baz"
+
+
+def test_custom_functions() -> None:
+    class C:
+        value: int
+
+        def __init__(self, value: int):
+            self.value = value
+
+    def _serialize(o: C) -> SerializedData:
+        return {"bin": o.value.to_bytes((o.value.bit_length() + 7) // 8, "little")}
+
+    def _deserialize(t: Type[C], data: SerializedData) -> C:
+        return t(int.from_bytes(data["bin"], "little"))
+
+    register_serialization(_serialize, _deserialize)
+
+    obj = C(22222222222)
+    deserialized_obj = deserialize(C, serialize(obj))
+    assert obj.value == deserialized_obj.value
+
+
+def test_extra_attrs():
+    @attrs.define
+    class C(Injectable):
+        f1: Optional[str]
+        f2: Optional[str]
+
+    obj = C(f1="foo", f2="bar")
+    serialized_obj = serialize(obj)
+    del serialized_obj["f1"]
+    deserialized_obj = deserialize(C, serialized_obj)
+    assert deserialized_obj.f1 is None
+    assert deserialized_obj.f2 == "bar"
+
+
+def test_write_data(book_list_html_response, tmp_path) -> None:
+    directory = tmp_path / "ser"
+    directory.mkdir()
+    po = WebPage(book_list_html_response)
+    serialized_po = serialize(po)
+    write_serialized_data(serialized_po, directory)
+    assert (directory / "response.body.html").exists()
+    read_serialized_po = read_serialized_data(directory)
+    deserialized_po = deserialize(WebPage, read_serialized_po)
+    assert type(deserialized_po) == WebPage
+    _compare_webpages(po, deserialized_po)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -32,12 +32,12 @@ def _assert_urls_equal(u1: _Url, u2: _Url) -> None:
 
 
 def test_serialization_leaf() -> None:
-    data = {"a": "b", "c": 42}
-    serialized_data = serialize_leaf(data)
-    assert isinstance(serialized_data["json"], bytes)
-    assert json.loads(serialized_data["json"]) == data
-    deserialized_data = deserialize_leaf(dict, serialized_data)
-    assert data == deserialized_data
+    leaf = HttpResponseBody(b"foo")
+    serialized_data = serialize_leaf(leaf)
+    assert isinstance(serialized_data["html"], bytes)
+    assert HttpResponseBody(serialized_data["html"]) == leaf
+    deserialized_data = deserialize_leaf(HttpResponseBody, serialized_data)
+    assert leaf == deserialized_data
 
 
 def test_serialization_leaf_unsupported() -> None:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -40,14 +40,18 @@ def test_serialization_leaf() -> None:
     assert data == deserialized_data
 
 
-def test_serialization_leaf_unsup() -> None:
+def test_serialization_leaf_unsupported() -> None:
     class A:
         pass
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(
+        NotImplementedError, match=r"Serialization .+ is not implemented"
+    ):
         serialize_leaf(A())
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(
+        NotImplementedError, match=r"Deserialization .+ is not implemented"
+    ):
         deserialize_leaf(A, {})
 
 
@@ -75,6 +79,11 @@ def test_serialization(book_list_html_response) -> None:
     po = MyWebPage(book_list_html_response, url)
     deserialized_po = deserialize(MyWebPage, serialized_deps)
     _assert_webpages_equal(po, deserialized_po)
+
+
+def test_serialization_injectable(book_list_html_response) -> None:
+    with pytest.raises(ValueError, match=r"Injectable type .+ passed"):
+        serialize([WebPage(book_list_html_response)])
 
 
 def test_serialization_httpresponse_encoding(book_list_html) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     pytest-asyncio
     requests
     aiohttp
+    andi
 
 commands =
     py.test \

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps =
     pytest-asyncio
     requests
     aiohttp
-    andi
 
 commands =
     py.test \

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     aiohttp
 
 commands =
-    py.test \
+    python -m pytest \
         --cov-report=term-missing:skip-covered \
         --cov-report=html \
         --cov-report= \
@@ -39,15 +39,11 @@ deps =
 
 commands = py.test {posargs: tests_typing}
 
-[docs]
+[testenv:docs]
 changedir = docs
+basepython = python3
 deps =
     -rdocs/requirements.txt
-
-[testenv:docs]
-basepython = python3
-changedir = {[docs]changedir}
-deps = {[docs]deps}
 commands =
     sphinx-build -W -b html . {envtmpdir}/html
 

--- a/web_poet/serialization/__init__.py
+++ b/web_poet/serialization/__init__.py
@@ -2,10 +2,13 @@ from . import functions  # needed to run register functions
 from .api import (
     DeserializeFunction,
     SerializedData,
+    SerializedLeafData,
     SerializeFunction,
     deserialize,
+    deserialize_leaf,
     read_serialized_data,
     register_serialization,
     serialize,
+    serialize_leaf,
     write_serialized_data,
 )

--- a/web_poet/serialization/__init__.py
+++ b/web_poet/serialization/__init__.py
@@ -1,0 +1,11 @@
+from . import functions  # needed to run register functions
+from .api import (
+    DeserializeFunction,
+    SerializedData,
+    SerializeFunction,
+    deserialize,
+    read_serialized_data,
+    register_serialization,
+    serialize,
+    write_serialized_data,
+)

--- a/web_poet/serialization/__init__.py
+++ b/web_poet/serialization/__init__.py
@@ -2,13 +2,12 @@ from . import functions  # needed to run register functions
 from .api import (
     DeserializeFunction,
     SerializedData,
+    SerializedDataFileStorage,
     SerializedLeafData,
     SerializeFunction,
     deserialize,
     deserialize_leaf,
-    read_serialized_data,
     register_serialization,
     serialize,
     serialize_leaf,
-    write_serialized_data,
 )

--- a/web_poet/serialization/api.py
+++ b/web_poet/serialization/api.py
@@ -93,20 +93,20 @@ def _deserialize_leaf_base(cls: Type[Any], data: SerializedLeafData) -> Any:
     raise NotImplementedError(f"Deserialization for {cls} is not implemented")
 
 
-serialize_leaf.f_deserialize = _deserialize_leaf_base
+serialize_leaf.f_deserialize = _deserialize_leaf_base  # type: ignore[attr-defined]
 serialize_leaf = singledispatch(serialize_leaf)
 
 
 def register_serialization(
     f_serialize: SerializeFunction, f_deserialize: DeserializeFunction
 ) -> None:
-    serialize_leaf.register(f_serialize)
-    f_serialize.f_deserialize = f_deserialize
+    serialize_leaf.register(f_serialize)  # type: ignore[attr-defined]
+    f_serialize.f_deserialize = f_deserialize  # type: ignore[attr-defined]
 
 
 def deserialize_leaf(cls: Type[T], data: SerializedLeafData) -> T:
-    f_ser: SerializeFunction = serialize_leaf.dispatch(cls)
-    return f_ser.f_deserialize(cls, data)
+    f_ser: SerializeFunction = serialize_leaf.dispatch(cls)  # type: ignore[attr-defined]
+    return f_ser.f_deserialize(cls, data)  # type: ignore[attr-defined]
 
 
 def _get_fqname(cls: type) -> str:
@@ -156,7 +156,7 @@ def _load_type(type_name: str) -> type:
 
 
 def deserialize(cls: Type[InjectableT], data: SerializedData) -> InjectableT:
-    deps: Dict[type, Any] = {}
+    deps: Dict[Callable, Any] = {}
 
     for dep_type_name, dep_data in data.items():
         dep_type = _load_type(dep_type_name)

--- a/web_poet/serialization/api.py
+++ b/web_poet/serialization/api.py
@@ -61,3 +61,12 @@ def register_serialization(
 def deserialize(t: Type[T], data: SerializedData) -> T:
     f_ser: SerializeFunction = serialize.dispatch(t)
     return f_ser.f_deserialize(t, data)
+
+
+def get_bytes(d: dict, key: str) -> bytes:
+    if key not in d:
+        raise ValueError(f"Expected key {key} not found")
+    value = d[key]
+    if not isinstance(value, bytes):
+        raise ValueError(f"Expected key {key} contains {type(value)} instead of bytes.")
+    return value

--- a/web_poet/serialization/api.py
+++ b/web_poet/serialization/api.py
@@ -142,13 +142,13 @@ def _load_type(type_name: str) -> type:
     >>> _load_type("foo.bar")
     Traceback (most recent call last):
      ...
-    ValueError: Unknown type foo.bar
+    ValueError: Unable to import module foo
     """
     module, name = type_name.rsplit(".", 1)
     try:
         mod = import_module(module)
     except ModuleNotFoundError:
-        raise ValueError(f"Unknown type {type_name}")
+        raise ValueError(f"Unable to import module {module}")
     result = getattr(mod, name, None)
     if not result:
         raise ValueError(f"Unknown type {type_name}")

--- a/web_poet/serialization/api.py
+++ b/web_poet/serialization/api.py
@@ -2,7 +2,7 @@ import os
 from functools import singledispatch
 from importlib import import_module
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import andi
 
@@ -19,33 +19,68 @@ SerializeFunction = Callable[[Any], SerializedLeafData]
 DeserializeFunction = Callable[[Type[T], SerializedLeafData], T]
 
 
+def _split_file_name(file_name: str) -> Tuple[str, str]:
+    """Extract the type name and the type-specific suffix from a file name.
+
+    >>> _split_file_name("TypeName.ext")
+    ('TypeName', 'ext')
+    >>> _split_file_name("Qualified.TypeName.ext")
+    ('Qualified.TypeName', 'ext')
+    >>> _split_file_name("TypeName-component.ext")
+    ('TypeName', 'component.ext')
+    >>> _split_file_name("Qualified.TypeName-component.ext")
+    ('Qualified.TypeName', 'component.ext')
+    >>> _split_file_name("Qualified.TypeName-component-with-dashes.ext")
+    ('Qualified.TypeName', 'component-with-dashes.ext')
+    """
+    if "-" in file_name:
+        type_name, suffix = file_name.split("-", 1)
+    else:
+        type_name, suffix = file_name.rsplit(".", 1)
+    return type_name, suffix
+
+
 def read_serialized_data(directory: Union[str, os.PathLike]) -> SerializedData:
     result: SerializedData = {}
     directory = Path(directory)
     for entry in directory.iterdir():
         if not entry.is_file():
             continue
-        if "-" in entry.name:
-            prefix, name = entry.name.split("-", 1)
-        else:
-            prefix, name = entry.name.rsplit(".", 1)
-        if prefix not in result:
-            result[prefix] = {}
-        result[prefix][name] = entry.read_bytes()
+        type_name, suffix = _split_file_name(entry.name)
+        if type_name not in result:
+            result[type_name] = {}
+        result[type_name][suffix] = entry.read_bytes()
     return result
+
+
+def _make_file_name(type_name: str, suffix: str) -> str:
+    """Combine the type name and the type-specific suffix into a file name.
+
+    >>> _make_file_name('TypeName', 'ext')
+    'TypeName.ext'
+    >>> _make_file_name('Qualified.TypeName', 'ext')
+    'Qualified.TypeName.ext'
+    >>> _make_file_name('TypeName', 'component.ext')
+    'TypeName-component.ext'
+    >>> _make_file_name('Qualified.TypeName', 'component.ext')
+    'Qualified.TypeName-component.ext'
+    >>> _make_file_name('Qualified.TypeName', 'component-with-dashes.ext')
+    'Qualified.TypeName-component-with-dashes.ext'
+    """
+    if "." not in suffix:
+        # TypeName.ext
+        return type_name + "." + suffix
+    else:
+        # TypeName-component.ext
+        return type_name + "-" + suffix
 
 
 def write_serialized_data(
     data: SerializedData, directory: Union[str, os.PathLike]
 ) -> None:
-    for prefix, leaf in data.items():
-        for name, contents in leaf.items():
-            if "." not in name:
-                # TypeName.ext
-                full_name = prefix + "." + name
-            else:
-                # TypeName-component.ext
-                full_name = prefix + "-" + name
+    for type_name, leaf in data.items():
+        for suffix, contents in leaf.items():
+            full_name = _make_file_name(type_name, suffix)
             file_name = Path(directory, full_name)
             file_name.write_bytes(contents)
 
@@ -54,8 +89,8 @@ def serialize_leaf(o: Any) -> SerializedLeafData:
     raise NotImplementedError(f"Serialization for {type(o)} is not implemented")
 
 
-def _deserialize_leaf_base(t: Type[Any], data: SerializedLeafData) -> Any:
-    raise NotImplementedError(f"Deserialization for {t} is not implemented")
+def _deserialize_leaf_base(cls: Type[Any], data: SerializedLeafData) -> Any:
+    raise NotImplementedError(f"Deserialization for {cls} is not implemented")
 
 
 serialize_leaf.f_deserialize = _deserialize_leaf_base
@@ -69,31 +104,49 @@ def register_serialization(
     f_serialize.f_deserialize = f_deserialize
 
 
-def deserialize_leaf(t: Type[T], data: SerializedLeafData) -> T:
-    f_ser: SerializeFunction = serialize_leaf.dispatch(t)
-    return f_ser.f_deserialize(t, data)
+def deserialize_leaf(cls: Type[T], data: SerializedLeafData) -> T:
+    f_ser: SerializeFunction = serialize_leaf.dispatch(cls)
+    return f_ser.f_deserialize(cls, data)
 
 
-def _get_fqname(t: type) -> str:
-    return f"{t.__module__}.{t.__qualname__}"
+def _get_fqname(cls: type) -> str:
+    """Return the fully qualified name for a type.
+
+    >>> _get_fqname(Injectable)
+    'web_poet.pages.Injectable'
+    """
+    return f"{cls.__module__}.{cls.__qualname__}"
 
 
 def serialize(deps: List[Any]) -> SerializedData:
-    # we skip injectable classes though the interface should probably not accept them at all
-    return {
-        _get_fqname(dep.__class__): serialize_leaf(dep)
-        for dep in deps
-        if not is_injectable(dep.__class__)
-    }
+    result: SerializedData = {}
+    for dep in deps:
+        cls = dep.__class__
+        if is_injectable(cls):
+            raise ValueError(f"Injectable type {cls} passed to serialize()")
+        result[_get_fqname(cls)] = serialize_leaf(dep)
+    return result
 
 
 def _load_type(type_name: str) -> Optional[type]:
+    """Return the type by its fully qualified name.
+
+    >>> _load_type("decimal.Decimal")
+    <class 'decimal.Decimal'>
+    >>> _load_type("web_poet.pages.WebPage")
+    <class 'web_poet.pages.WebPage'>
+    >>> _load_type("decimal.foo")
+    >>> _load_type("foo.bar")
+    """
     module, name = type_name.rsplit(".", 1)
-    mod = import_module(module)
+    try:
+        mod = import_module(module)
+    except ModuleNotFoundError:
+        return None
     return getattr(mod, name, None)
 
 
-def deserialize(t: Type[InjectableT], data: SerializedData) -> InjectableT:
+def deserialize(cls: Type[InjectableT], data: SerializedData) -> InjectableT:
     deps: Dict[type, Any] = {}
 
     for dep_type_name, dep_data in data.items():
@@ -102,5 +155,5 @@ def deserialize(t: Type[InjectableT], data: SerializedData) -> InjectableT:
             raise ValueError(f"Unknown serialized type {dep_type_name}")
         deps[dep_type] = deserialize_leaf(dep_type, dep_data)
 
-    plan = andi.plan(t, is_injectable=is_injectable, externally_provided=deps.keys())
-    return t(**plan.final_kwargs(deps))
+    plan = andi.plan(cls, is_injectable=is_injectable, externally_provided=deps.keys())
+    return cls(**plan.final_kwargs(deps))

--- a/web_poet/serialization/api.py
+++ b/web_poet/serialization/api.py
@@ -1,0 +1,63 @@
+import os
+from functools import singledispatch
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Type, TypeVar, Union
+
+T = TypeVar("T")
+SerializedData = Dict[str, Union[bytes, "SerializedData"]]
+SerializeFunction = Callable[[Any], SerializedData]
+DeserializeFunction = Callable[[Type[T], SerializedData], T]
+
+
+def read_serialized_data(directory: Union[str, os.PathLike]) -> SerializedData:
+    result: SerializedData = {}
+    directory = Path(directory)
+    for entry in directory.iterdir():
+        if not entry.is_file():
+            continue
+        *keys, ext = entry.name.split(".")
+        node = result
+        for key in keys:
+            if key not in node:
+                node[key] = {}
+            node = node[key]
+        node[ext] = entry.read_bytes()
+    return result
+
+
+def write_serialized_data(
+    data: SerializedData,
+    directory: Union[str, os.PathLike],
+    prefix: Optional[str] = None,
+) -> None:
+    for k, v in data.items():
+        new_prefix = prefix + "." + k if prefix else k
+        if isinstance(v, bytes):
+            file_name = Path(directory, new_prefix)
+            file_name.write_bytes(v)
+        elif isinstance(v, dict):
+            write_serialized_data(v, directory, new_prefix)
+
+
+def serialize(o: Any) -> SerializedData:
+    raise NotImplementedError(f"Serialization for {type(o)} is not implemented")
+
+
+def _deserialize_base(t: Type[Any], data: SerializedData) -> Any:
+    raise NotImplementedError(f"Deserialization for {t} is not implemented")
+
+
+serialize.f_deserialize = _deserialize_base
+serialize = singledispatch(serialize)
+
+
+def register_serialization(
+    f_serialize: SerializeFunction, f_deserialize: DeserializeFunction
+) -> None:
+    serialize.register(f_serialize)
+    f_serialize.f_deserialize = f_deserialize
+
+
+def deserialize(t: Type[T], data: SerializedData) -> T:
+    f_ser: SerializeFunction = serialize.dispatch(t)
+    return f_ser.f_deserialize(t, data)

--- a/web_poet/serialization/functions.py
+++ b/web_poet/serialization/functions.py
@@ -1,99 +1,55 @@
 import json
-from typing import Any, Dict, Generic, Type, Union
+from typing import Type
 
-import attrs
-
-from .. import (
-    HttpResponse,
-    HttpResponseBody,
-    HttpResponseHeaders,
-    Injectable,
-    ResponseUrl,
-)
+from .. import HttpResponse, HttpResponseBody, HttpResponseHeaders, ResponseUrl
 from ..page_inputs.url import _Url
-from .api import SerializedData, deserialize, register_serialization, serialize
+from .api import (
+    SerializedLeafData,
+    deserialize_leaf,
+    register_serialization,
+    serialize_leaf,
+)
 
 
-def _serialize_dict(o: dict) -> SerializedData:
+def _serialize_dict(o: dict) -> SerializedLeafData:
     return {"json": json.dumps(o).encode()}
 
 
-def _deserialize_dict(t: Type[dict], data: SerializedData) -> dict:
+def _deserialize_dict(t: Type[dict], data: SerializedLeafData) -> dict:
     return t(json.loads(data["json"]))
 
 
 register_serialization(_serialize_dict, _deserialize_dict)
 
 
-def _serialize_Injectable(o: Injectable) -> SerializedData:
-    # None is Injectable
-    if o is None:
-        return {}
-
-    assert attrs.has(o)  # FIXME
-    deps = attrs.asdict(o, recurse=False)
-    return {dep_name: serialize(dep) for dep_name, dep in deps.items()}
-
-
-def _deserialize_Injectable(t: Type[Injectable], data: SerializedData) -> Injectable:
-    def _strip_Optional(t: Type) -> Type:
-        # Python >= 3.8
-        try:
-            from typing import get_args, get_origin
-        # Compatibility
-        except ImportError:
-            get_args = (
-                lambda t: getattr(t, "__args__", ()) if t is not Generic else Generic
-            )
-            get_origin = lambda t: getattr(t, "__origin__", None)  # noqa: E731
-        args = get_args(t)
-        if (
-            get_origin(t) is Union
-            and len(args) == 2
-            and args[1] == type(None)  # noqa: E721
-        ):
-            return args[0]
-        return t
-
-    # None is Injectable
-    if t is Type[None]:
-        return None
-
-    assert attrs.has(t)  # FIXME
-    attributes = attrs.fields_dict(t)
-    attributes_data: Dict[str, Any] = {}
-    for attr_name in attributes:
-        if not data.get(attr_name):
-            attributes_data[attr_name] = None
-        else:
-            attr_type = attributes[attr_name].type
-            attr_type = _strip_Optional(attr_type)
-            attr_data = deserialize(attr_type, data[attr_name])
-            attributes_data[attr_name] = attr_data
-    return t(**attributes_data)
-
-
-register_serialization(_serialize_Injectable, _deserialize_Injectable)
-
-
-def _serialize_HttpResponse(o: HttpResponse) -> SerializedData:
+def _serialize_HttpResponse(o: HttpResponse) -> SerializedLeafData:
     other_data = {
         "url": str(o.url),
         "status": o.status,
         "headers": list(o.headers.items()),
         "_encoding": o._encoding,
     }
-    return {
-        "body": serialize(o.body),
-        "other": serialize(other_data),
-    }
+    body_serialized = serialize_leaf(o.body)
+    other_serialized = serialize_leaf(other_data)
+    result = {}
+    result.update({f"body.{k}": v for k, v in body_serialized.items()})
+    result.update({f"other.{k}": v for k, v in other_serialized.items()})
+    return result
 
 
 def _deserialize_HttpResponse(
-    t: Type[HttpResponse], data: SerializedData
+    t: Type[HttpResponse], data: SerializedLeafData
 ) -> HttpResponse:
-    body = deserialize(HttpResponseBody, data["body"])
-    other_data = deserialize(dict, data["other"])
+    body_serialized = {}
+    other_serialized = {}
+    for k, v in data.items():
+        if k.startswith("body."):
+            body_serialized[k[len("body.") :]] = v
+        elif k.startswith("other."):
+            other_serialized[k[len("other.") :]] = v
+
+    body = deserialize_leaf(HttpResponseBody, body_serialized)
+    other_data = deserialize_leaf(dict, other_serialized)
     return t(
         body=body,
         url=ResponseUrl(other_data["url"]),
@@ -106,12 +62,12 @@ def _deserialize_HttpResponse(
 register_serialization(_serialize_HttpResponse, _deserialize_HttpResponse)
 
 
-def _serialize_HttpResponseBody(o: HttpResponseBody) -> SerializedData:
+def _serialize_HttpResponseBody(o: HttpResponseBody) -> SerializedLeafData:
     return {"html": bytes(o)}
 
 
 def _deserialize_HttpResponseBody(
-    t: Type[HttpResponseBody], data: SerializedData
+    t: Type[HttpResponseBody], data: SerializedLeafData
 ) -> HttpResponseBody:
     return t(data["html"])
 
@@ -119,33 +75,33 @@ def _deserialize_HttpResponseBody(
 register_serialization(_serialize_HttpResponseBody, _deserialize_HttpResponseBody)
 
 
-def _serialize_bytes(o: bytes) -> SerializedData:
+def _serialize_bytes(o: bytes) -> SerializedLeafData:
     return {"bin": bytes(o)}
 
 
-def _deserialize_bytes(t: Type[bytes], data: SerializedData) -> bytes:
+def _deserialize_bytes(t: Type[bytes], data: SerializedLeafData) -> bytes:
     return t(data["bin"])
 
 
 register_serialization(_serialize_bytes, _deserialize_bytes)
 
 
-def _serialize_str(o: str) -> SerializedData:
+def _serialize_str(o: str) -> SerializedLeafData:
     return {"txt": o.encode()}
 
 
-def _deserialize_str(t: Type[str], data: SerializedData) -> str:
+def _deserialize_str(t: Type[str], data: SerializedLeafData) -> str:
     return t(data["txt"].decode())
 
 
 register_serialization(_serialize_str, _deserialize_str)
 
 
-def _serialize__Url(o: _Url) -> SerializedData:
+def _serialize__Url(o: _Url) -> SerializedLeafData:
     return {"txt": str(o).encode()}
 
 
-def _deserialize__Url(t: Type[_Url], data: SerializedData) -> _Url:
+def _deserialize__Url(t: Type[_Url], data: SerializedLeafData) -> _Url:
     return t(data["txt"].decode())
 
 

--- a/web_poet/serialization/functions.py
+++ b/web_poet/serialization/functions.py
@@ -12,11 +12,11 @@ from .api import (
 
 
 def _serialize_dict(o: dict) -> SerializedLeafData:
-    return {"json": json.dumps(o).encode()}
+    return {"json": json.dumps(o, ensure_ascii=False, sort_keys=True).encode()}
 
 
-def _deserialize_dict(t: Type[dict], data: SerializedLeafData) -> dict:
-    return t(json.loads(data["json"]))
+def _deserialize_dict(cls: Type[dict], data: SerializedLeafData) -> dict:
+    return cls(json.loads(data["json"]))
 
 
 register_serialization(_serialize_dict, _deserialize_dict)
@@ -38,7 +38,7 @@ def _serialize_HttpResponse(o: HttpResponse) -> SerializedLeafData:
 
 
 def _deserialize_HttpResponse(
-    t: Type[HttpResponse], data: SerializedLeafData
+    cls: Type[HttpResponse], data: SerializedLeafData
 ) -> HttpResponse:
     body_serialized = {}
     other_serialized = {}
@@ -50,7 +50,7 @@ def _deserialize_HttpResponse(
 
     body = deserialize_leaf(HttpResponseBody, body_serialized)
     other_data = deserialize_leaf(dict, other_serialized)
-    return t(
+    return cls(
         body=body,
         url=ResponseUrl(other_data["url"]),
         status=other_data["status"],
@@ -67,9 +67,9 @@ def _serialize_HttpResponseBody(o: HttpResponseBody) -> SerializedLeafData:
 
 
 def _deserialize_HttpResponseBody(
-    t: Type[HttpResponseBody], data: SerializedLeafData
+    cls: Type[HttpResponseBody], data: SerializedLeafData
 ) -> HttpResponseBody:
-    return t(data["html"])
+    return cls(data["html"])
 
 
 register_serialization(_serialize_HttpResponseBody, _deserialize_HttpResponseBody)
@@ -79,8 +79,8 @@ def _serialize_bytes(o: bytes) -> SerializedLeafData:
     return {"bin": bytes(o)}
 
 
-def _deserialize_bytes(t: Type[bytes], data: SerializedLeafData) -> bytes:
-    return t(data["bin"])
+def _deserialize_bytes(cls: Type[bytes], data: SerializedLeafData) -> bytes:
+    return cls(data["bin"])
 
 
 register_serialization(_serialize_bytes, _deserialize_bytes)
@@ -90,8 +90,8 @@ def _serialize_str(o: str) -> SerializedLeafData:
     return {"txt": o.encode()}
 
 
-def _deserialize_str(t: Type[str], data: SerializedLeafData) -> str:
-    return t(data["txt"].decode())
+def _deserialize_str(cls: Type[str], data: SerializedLeafData) -> str:
+    return cls(data["txt"].decode())
 
 
 register_serialization(_serialize_str, _deserialize_str)
@@ -101,8 +101,8 @@ def _serialize__Url(o: _Url) -> SerializedLeafData:
     return {"txt": str(o).encode()}
 
 
-def _deserialize__Url(t: Type[_Url], data: SerializedLeafData) -> _Url:
-    return t(data["txt"].decode())
+def _deserialize__Url(cls: Type[_Url], data: SerializedLeafData) -> _Url:
+    return cls(data["txt"].decode())
 
 
 register_serialization(_serialize__Url, _deserialize__Url)

--- a/web_poet/serialization/functions.py
+++ b/web_poet/serialization/functions.py
@@ -19,7 +19,7 @@ def _serialize_dict(o: dict) -> SerializedData:
 
 
 def _deserialize_dict(t: Type[dict], data: SerializedData) -> dict:
-    return t(json.loads(data["json"].decode()))
+    return t(json.loads(data["json"]))
 
 
 register_serialization(_serialize_dict, _deserialize_dict)

--- a/web_poet/serialization/functions.py
+++ b/web_poet/serialization/functions.py
@@ -1,5 +1,4 @@
 import json
-from types import NoneType
 from typing import Any, Dict, Generic, Type, Union
 
 import attrs
@@ -48,7 +47,11 @@ def _deserialize_Injectable(t: Type[Injectable], data: SerializedData) -> Inject
             )
             get_origin = lambda t: getattr(t, "__origin__", None)  # noqa: E731
         args = get_args(t)
-        if get_origin(t) is Union and len(args) == 2 and args[1] == NoneType:
+        if (
+            get_origin(t) is Union
+            and len(args) == 2
+            and args[1] == type(None)  # noqa: E721
+        ):
             return args[0]
         return t
 

--- a/web_poet/serialization/functions.py
+++ b/web_poet/serialization/functions.py
@@ -1,0 +1,149 @@
+import json
+from types import NoneType
+from typing import Any, Dict, Generic, Type, Union
+
+import attrs
+
+from .. import (
+    HttpResponse,
+    HttpResponseBody,
+    HttpResponseHeaders,
+    Injectable,
+    ResponseUrl,
+)
+from ..page_inputs.url import _Url
+from .api import SerializedData, deserialize, register_serialization, serialize
+
+
+def _serialize_dict(o: dict) -> SerializedData:
+    return {"json": json.dumps(o).encode()}
+
+
+def _deserialize_dict(t: Type[dict], data: SerializedData) -> dict:
+    return t(json.loads(data["json"].decode()))
+
+
+register_serialization(_serialize_dict, _deserialize_dict)
+
+
+def _serialize_Injectable(o: Injectable) -> SerializedData:
+    # None is Injectable
+    if o is None:
+        return {}
+
+    assert attrs.has(o)  # FIXME
+    deps = attrs.asdict(o, recurse=False)
+    return {dep_name: serialize(dep) for dep_name, dep in deps.items()}
+
+
+def _deserialize_Injectable(t: Type[Injectable], data: SerializedData) -> Injectable:
+    def _strip_Optional(t: Type) -> Type:
+        # Python >= 3.8
+        try:
+            from typing import get_args, get_origin
+        # Compatibility
+        except ImportError:
+            get_args = (
+                lambda t: getattr(t, "__args__", ()) if t is not Generic else Generic
+            )
+            get_origin = lambda t: getattr(t, "__origin__", None)  # noqa: E731
+        args = get_args(t)
+        if get_origin(t) is Union and len(args) == 2 and args[1] == NoneType:
+            return args[0]
+        return t
+
+    # None is Injectable
+    if t is Type[None]:
+        return None
+
+    assert attrs.has(t)  # FIXME
+    attributes = attrs.fields_dict(t)
+    attributes_data: Dict[str, Any] = {}
+    for attr_name in attributes:
+        if not data.get(attr_name):
+            attributes_data[attr_name] = None
+        else:
+            attr_type = attributes[attr_name].type
+            attr_type = _strip_Optional(attr_type)
+            attr_data = deserialize(attr_type, data[attr_name])
+            attributes_data[attr_name] = attr_data
+    return t(**attributes_data)
+
+
+register_serialization(_serialize_Injectable, _deserialize_Injectable)
+
+
+def _serialize_HttpResponse(o: HttpResponse) -> SerializedData:
+    other_data = {
+        "url": str(o.url),
+        "status": o.status,
+        "headers": list(o.headers.items()),
+        "_encoding": o._encoding,
+    }
+    return {
+        "body": serialize(o.body),
+        "other": serialize(other_data),
+    }
+
+
+def _deserialize_HttpResponse(
+    t: Type[HttpResponse], data: SerializedData
+) -> HttpResponse:
+    body = deserialize(HttpResponseBody, data["body"])
+    other_data = deserialize(dict, data["other"])
+    return t(
+        body=body,
+        url=ResponseUrl(other_data["url"]),
+        status=other_data["status"],
+        headers=HttpResponseHeaders(other_data["headers"]),
+        encoding=other_data["_encoding"],
+    )
+
+
+register_serialization(_serialize_HttpResponse, _deserialize_HttpResponse)
+
+
+def _serialize_HttpResponseBody(o: HttpResponseBody) -> SerializedData:
+    return {"html": bytes(o)}
+
+
+def _deserialize_HttpResponseBody(
+    t: Type[HttpResponseBody], data: SerializedData
+) -> HttpResponseBody:
+    return t(data["html"])
+
+
+register_serialization(_serialize_HttpResponseBody, _deserialize_HttpResponseBody)
+
+
+def _serialize_bytes(o: bytes) -> SerializedData:
+    return {"bin": bytes(o)}
+
+
+def _deserialize_bytes(t: Type[bytes], data: SerializedData) -> bytes:
+    return t(data["bin"])
+
+
+register_serialization(_serialize_bytes, _deserialize_bytes)
+
+
+def _serialize_str(o: str) -> SerializedData:
+    return {"txt": o.encode()}
+
+
+def _deserialize_str(t: Type[str], data: SerializedData) -> str:
+    return t(data["txt"].decode())
+
+
+register_serialization(_serialize_str, _deserialize_str)
+
+
+def _serialize__Url(o: _Url) -> SerializedData:
+    return {"txt": str(o).encode()}
+
+
+def _deserialize__Url(t: Type[_Url], data: SerializedData) -> _Url:
+    return t(data["txt"].decode())
+
+
+register_serialization(_serialize__Url, _deserialize__Url)


### PR DESCRIPTION
This is WIP but ready for review. It doesn't have docs yet and wasn't tested as a cache replacement in scrapy-poet.

The basic idea:

* This is mostly for serializing page objects and their attributes recursively. So it has some custom support for web-poet classes but otherwise Injectable attr-classes are serialized recursively.
* This means that unless a custom function is written (and it's written for `HttpResponse`), every attr-class is converted into a tree where leaves are primitive types. `HttpResponse`, on the other hand, is just two leaves: the body and a dict with all other fields (we wanted to save the body as a plain HTML file and to make sure we support custom serialization).
* The tree (a dict with dicts as nodes and `bytes` objects as leaves, typed as `SerializedData`) does not contain any typing information, only the raw data and attribute names to map it to attributes. To recreate the object we need its type definition. Then we can find the raw data for every attribute by its name and recreate it using its type.
* The tree is flattened when written to the disk, using dots as separators of node names (the `SerializedData` structure cleanly maps to a file system tree structure but I see no reason so far to use subdirectories). A top-level class is thus represented by a directory with files inside. As an example, a directory for a `WebPage` object contains two files: `response.body.html` and `response.other.json`. A `WebPage` descendant that also has a `response_url: ResponseUrl` field serializes into three files, adding `response_url.txt`. (As an implementation detail, the leaves in the tree have the file extension as the key in the parent dict, this looked like the cleanest solution to the problem that serializing a variable shouldn't need the variable name.)
* The dynamic serialization is implemented with [functools.singledispatch](https://docs.python.org/3/library/functools.html#functools.singledispatch). The function signature is `_(o: T) -> SerializedData`, and dispatching is done by the type of `o`.
* The dynamic deserialization cannot use the same mechanism, as it needs to take the type, not the object, so we store the deserialization function as an attribute of the paired serialization one and find it using `serialize.dispatch()` which takes the type. The function signature is `_(t: Type[T], data: SerializedData) -> T`.
* We expose the singledispatch-decorated `serialize()`, the wrapper that finds and calls the correct deserialization function as `deserialize()` and a `register_serialization()` function that takes a function pair and registers them. 
* Currently, as a limitation, Injectable descendants are assumed to be attr-classes, this needs to be fixed (note that there is no common ancestor, and so no straightforward way to dispatch, for attr-classes).