### PR TITLE
FieldsMixin: ignore AttributeError from delattr

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -3,7 +3,6 @@ import random
 
 import attrs
 import pytest
-from attrs import define
 
 from tests.po_lib_to_return import (
     CustomProductPage,
@@ -455,7 +454,6 @@ async def test_field_processors_async() -> None:
 
 
 def test_field_mixin() -> None:
-    @define
     class A(ItemPage):
         @field
         def a(self):
@@ -466,7 +464,6 @@ def test_field_mixin() -> None:
         def mixin(self):
             return None
 
-    @define
     class B(Mixin, A):
         @field
         def b(self):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -451,3 +451,15 @@ async def test_field_processors_async() -> None:
 
     page = Page()
     assert await page.name == "namex"
+
+
+def test_field_mixin() -> None:
+    class Mixin:
+        @field
+        def a(self):
+            return "a"
+
+    class A(ItemPage, Mixin):
+        pass
+
+    assert list(get_fields_dict(A)) == ["a"]

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -3,6 +3,7 @@ import random
 
 import attrs
 import pytest
+from attrs import define
 
 from tests.po_lib_to_return import (
     CustomProductPage,
@@ -454,12 +455,21 @@ async def test_field_processors_async() -> None:
 
 
 def test_field_mixin() -> None:
-    class Mixin:
+    @define
+    class A(ItemPage):
         @field
         def a(self):
-            return "a"
+            return None
 
-    class A(ItemPage, Mixin):
-        pass
+    class Mixin:
+        @field
+        def mixin(self):
+            return None
 
-    assert list(get_fields_dict(A)) == ["a"]
+    @define
+    class B(Mixin, A):
+        @field
+        def b(self):
+            return None
+
+    assert set(get_fields_dict(B)) == {"a", "b", "mixin"}

--- a/web_poet/fields.py
+++ b/web_poet/fields.py
@@ -3,6 +3,7 @@
 into separate Page Object methods / properties.
 """
 import inspect
+from contextlib import suppress
 from functools import update_wrapper, wraps
 from typing import Callable, Dict, List, Optional, Type, TypeVar
 
@@ -44,7 +45,8 @@ class FieldsMixin:
             fields = {**base_class_fields, **this_class_fields}
             setattr(cls, _FIELDS_INFO_ATTRIBUTE_READ, fields)
             if hasattr(cls, _FIELDS_INFO_ATTRIBUTE_WRITE):
-                delattr(cls, _FIELDS_INFO_ATTRIBUTE_WRITE)
+                with suppress(AttributeError):
+                    delattr(cls, _FIELDS_INFO_ATTRIBUTE_WRITE)
 
 
 def field(

--- a/web_poet/fields.py
+++ b/web_poet/fields.py
@@ -44,9 +44,8 @@ class FieldsMixin:
         if base_class_fields or this_class_fields:
             fields = {**base_class_fields, **this_class_fields}
             setattr(cls, _FIELDS_INFO_ATTRIBUTE_READ, fields)
-            if hasattr(cls, _FIELDS_INFO_ATTRIBUTE_WRITE):
-                with suppress(AttributeError):
-                    delattr(cls, _FIELDS_INFO_ATTRIBUTE_WRITE)
+            with suppress(AttributeError):
+                delattr(cls, _FIELDS_INFO_ATTRIBUTE_WRITE)
 
 
 def field(


### PR DESCRIPTION
I found that I needed this change to be able to [use a mixin for `ItemPage` subclasses that implements fields](https://github.com/zytedata/zyte-common-items/pull/19), since the mixin itself is not (*cannot be*, I think) an `ItemPage` subclass.