### PR TITLE
Introduce `SelectFields`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -44,6 +44,7 @@ per-file-ignores =
     web_poet/serialization/__init__.py:F401,F403
     web_poet/testing/__init__.py:F401,F403
     tests/po_lib_to_return/__init__.py:D102
+    tests/test_fields.py:D102
 
     # the suggestion makes the code worse
     tests/test_serialization.py:B028

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -643,14 +643,6 @@ class BigItem:
 
 
 @attrs.define
-class SmallItem:
-    """Same with ``BigItem`` but removes the required ``x`` field."""
-
-    y: Optional[int] = None
-    z: Optional[int] = None
-
-
-@attrs.define
 class BigPage(ItemPage[BigItem]):
     select_fields: Optional[SelectFields] = None
     call_counter: DefaultDict = attrs.field(factory=lambda: defaultdict(int))
@@ -911,27 +903,3 @@ async def test_select_fields_include_exclude() -> None:
         assert item == BigItem(x=1, y=None, z=3)
         assert page.fields_to_extract == {"x", "z"}
         assert page.call_counter == {"x": 1, "z": 1}
-
-
-@pytest.mark.asyncio
-async def test_select_fields_swap_item_cls() -> None:
-    # Basic case
-    page = BigPage(SelectFields(exclude=["x"], swap_item_cls=SmallItem))
-    item = await page.to_item()
-    assert item == SmallItem(y=2, z=3)
-    assert page.fields_to_extract == {"y", "z"}
-    assert page.call_counter == {"y": 1, "z": 1}
-
-    page = BigPage(SelectFields(include=["y", "z"], swap_item_cls=SmallItem))
-    item = await page.to_item()
-    assert item == SmallItem(y=2, z=3)
-    assert page.fields_to_extract == {"y", "z"}
-    assert page.call_counter == {"y": 1, "z": 1}
-
-    # If page object supplies the new item class with unknown fields, it should
-    # raise an error
-    expected_type_error_msg = r"__init__\(\) got an unexpected keyword argument 'x'"
-    page = BigPage(SelectFields(swap_item_cls=SmallItem))
-    with pytest.raises(TypeError, match=expected_type_error_msg):
-        await page.to_item()
-    assert page.fields_to_extract == {"x", "y", "z"}

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -728,7 +728,7 @@ async def test_select_fields() -> None:
     assert page.fields_to_extract == ["x", "y", "z"]
     assert page.call_counter == {"x": 1, "y": 1, "z": 1}
 
-    # Exluding a required field throws an error
+    # Excluding a required field throws an error
     page = BigPage(SelectFields(fields={"x": False}))
     with pytest.raises(TypeError, match=expected_type_error_msg):
         item = await page.to_item()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -757,7 +757,7 @@ async def test_select_fields_on_unknown_field_bad_value() -> None:
     )
     with pytest.raises(ValueError, match=expected_value_error_msg):
         await BigPage(
-            # ignore mypy error since it's expecting a value inside the Literal.
+            # ignore mypy error since it's expecting a valid value inside the Literal.
             SelectFields(include=["y", "not_existing"], on_unknown_field=invalid_val)  # type: ignore[arg-type]
         ).to_item()
 

--- a/tests_typing/test_fields.mypy-testing
+++ b/tests_typing/test_fields.mypy-testing
@@ -6,6 +6,7 @@ from web_poet import (
     field,
     item_from_fields,
     item_from_fields_sync,
+    SelectFields,
 )
 
 
@@ -138,3 +139,12 @@ async def test_item_from_fields_default_item_cls() -> None:
     page = Page()
     item1 = await item_from_fields(page)
     reveal_type(item1)  # R: builtins.dict[Any, Any]
+
+
+@pytest.mark.mypy_testing
+def test_select_fields_on_unknown_field() -> None:
+    SelectFields(fields={}, on_unknown_field="raise")
+    SelectFields(fields={}, on_unknown_field="warn")
+    SelectFields(fields={}, on_unknown_field="ignore")
+
+    SelectFields(fields={}, on_unknown_field="bad value")  # E: Argument "on_unknown_field" to "SelectFields" has incompatible type "Literal['bad value']"; expected "Literal['ignore', 'warn', 'raise']"  [arg-type]

--- a/web_poet/__init__.py
+++ b/web_poet/__init__.py
@@ -1,4 +1,4 @@
-from .fields import field, item_from_fields, item_from_fields_sync
+from .fields import SelectFields, field, item_from_fields, item_from_fields_sync
 from .page_inputs import (
     BrowserHtml,
     HttpClient,

--- a/web_poet/fields.py
+++ b/web_poet/fields.py
@@ -204,7 +204,7 @@ async def item_from_fields(
         field_names=field_names,
         on_unknown_field=on_unknown_field,
     )
-    if not field_names:
+    if field_names is None:
         field_names = list(item_dict.keys())
     if skip_nonitem_fields:
         field_names = _without_unsupported_field_names(item_cls, field_names)
@@ -226,7 +226,7 @@ def item_from_fields_sync(
     on_unknown_field: UnknownFieldActions = "raise",
 ) -> T:
     """Synchronous version of :func:`item_from_fields`."""
-    if not field_names:
+    if field_names is None:
         field_names = list(get_fields_dict(obj))
         if skip_nonitem_fields:
             field_names = _without_unsupported_field_names(item_cls, field_names)
@@ -241,7 +241,7 @@ def item_from_fields_sync(
 
 def _handle_unknown_field(obj, name, action: UnknownFieldActions = "raise") -> None:
     if action == "ignore":
-        return
+        return None
 
     msg = f"Field '{name}' isn't available in {get_fq_class_name(obj.__class__)}."
 

--- a/web_poet/fields.py
+++ b/web_poet/fields.py
@@ -285,8 +285,3 @@ class SelectFields:
     #: Setting it to ``"raise"`` would raise an :class:`AttributeError`,
     #: ``"warn"`` produces a :class:`UserWarning`, while ``"ignore"`` does nothing.
     on_unknown_field: UnknownFieldActions = "raise"
-
-    #: Swaps the item class that the page object returns. Use this to prevent
-    #: errors when excluding a required field by swapping the assigned item class
-    #: without the required field.
-    swap_item_cls: Optional[Type] = None

--- a/web_poet/fields.py
+++ b/web_poet/fields.py
@@ -268,9 +268,25 @@ def _without_unsupported_field_names(
 
 @attrs.define
 class SelectFields:
+    """This is used as a dependency in a page object to control which fields it
+    would populate the item class that it returns.
+    """
+
+    #: Fields that the page object would use to populate its item class.
     include: Optional[Iterable[str]] = None
+
+    #: Fields that the page object would exclude when populating its item class.
     exclude: Optional[Iterable[str]] = None
-    # when encountering an unknown field even after perfomring include/exclucde
-    # {"x", "not-exist-1", "not-exist-2"} - {"not-exist-1"}
+
+    #: Controls what happens when encountering an unknown field. For example,
+    #: an unknown field was passed via 'include' and the page object doesn't
+    #: recognize it.
+    #:
+    #: Setting it to ``"raise"`` would raise an :class:`AttributeError`,
+    #: ``"warn"`` produces a :class:`UserWarning`, while ``"ignore"`` does nothing.
     on_unknown_field: UnknownFieldActions = "raise"
+
+    #: Swaps the item class that the page object returns. Use this to prevent
+    #: errors when excluding a required field by swapping the assigned item class
+    #: without the required field.
     swap_item_cls: Optional[Type] = None

--- a/web_poet/fields.py
+++ b/web_poet/fields.py
@@ -211,8 +211,7 @@ async def item_from_fields(
         skip_nonitem_fields=False,
         field_names=field_names,
     )
-    if field_names is None:
-        field_names = list(item_dict.keys())
+    field_names = field_names or list(item_dict.keys())
     if skip_nonitem_fields:
         field_names = _without_unsupported_field_names(item_cls, field_names)
     return item_cls(
@@ -230,8 +229,8 @@ def item_from_fields_sync(
     """Synchronous version of :func:`item_from_fields`."""
     if field_names is None:
         field_names = list(get_fields_dict(obj))
-        if skip_nonitem_fields:
-            field_names = _without_unsupported_field_names(item_cls, field_names)
+    if skip_nonitem_fields:
+        field_names = _without_unsupported_field_names(item_cls, field_names)
     return item_cls(**{name: getattr(obj, name) for name in field_names})
 
 

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -72,7 +72,8 @@ class ItemPage(Injectable, Returns[ItemT]):
             self, item_cls=self.item_cls, skip_nonitem_fields=self._skip_nonitem_fields
         )
 
-    # TODO: cache
+    # TODO: cache, or maybe not? since users could swap the select_field to
+    # reuse the same instance.
     def _get_select_fields(self) -> Optional[SelectFields]:
         select_fields = getattr(self, "select_fields", None)
         if not select_fields:
@@ -96,9 +97,13 @@ class ItemPage(Injectable, Returns[ItemT]):
         if select_fields is None:
             return None
         all_fields = get_fields_dict(self).keys()
-        return (set(select_fields.include or []) or all_fields) - set(
+
+        if isinstance(select_fields.include, list) and len(select_fields.include) == 0:
+            return select_fields.include
+        fields = (set(select_fields.include or []) or all_fields) - set(
             select_fields.exclude or []
         )
+        return fields
 
     async def _partial_item(self) -> Optional[Any]:
         # TODO: Should we support other naming conventions? this means we need

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -105,7 +105,7 @@ class ItemPage(Injectable, Returns[ItemT]):
             return None
 
         if isinstance(select_fields.include, list) and len(select_fields.include) == 0:
-            return select_fields.include
+            return set()
 
         page_obj_fields = get_fields_dict(self).keys()
         fields = (set(select_fields.include or []) or page_obj_fields) - set(

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -70,13 +70,11 @@ class ItemPage(Injectable, Returns[ItemT]):
 
     async def to_item(self) -> ItemT:
         """Extract an item from a web page"""
-
-        partial_item = await self._partial_item()
-        if partial_item:
-            return partial_item
-
         return await item_from_fields(
-            self, item_cls=self.item_cls, skip_nonitem_fields=self._skip_nonitem_fields
+            self,
+            item_cls=self.item_cls,
+            skip_nonitem_fields=self._skip_nonitem_fields,
+            field_names=self.fields_to_extract,
         )
 
     def _get_select_fields(self) -> Optional[SelectFields]:
@@ -125,21 +123,6 @@ class ItemPage(Injectable, Returns[ItemT]):
                 fields_to_extract.append(name)
 
         return fields_to_extract
-
-    async def _partial_item(self) -> Optional[Any]:
-        """This only creates a partial item when the ``SelectField`` is set in
-        the page object.
-        """
-        select_fields = self._get_select_fields()
-        if not select_fields:
-            return None
-
-        return await item_from_fields(
-            self,
-            item_cls=self.item_cls,
-            skip_nonitem_fields=self._skip_nonitem_fields,
-            field_names=self.fields_to_extract,
-        )
 
     def _handle_unknown_field(
         self, name: Set[str], action: UnknownFieldActions = "raise"

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -119,7 +119,7 @@ class ItemPage(Injectable, Returns[ItemT]):
 
         return await item_from_fields(
             self,
-            item_cls=self.item_cls,
+            item_cls=select_fields.swap_item_cls or self.item_cls,
             skip_nonitem_fields=self._skip_nonitem_fields,
             field_names=field_names,
             on_unknown_field=select_fields.on_unknown_field,

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -120,7 +120,7 @@ class ItemPage(Injectable, Returns[ItemT]):
 
         return await item_from_fields(
             self,
-            item_cls=select_fields.swap_item_cls or self.item_cls,
+            item_cls=self.item_cls,
             skip_nonitem_fields=self._skip_nonitem_fields,
             field_names=self.fields_to_extract,
             on_unknown_field=select_fields.on_unknown_field,

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -1,13 +1,20 @@
 import abc
-from typing import Any, Generic, Iterable, Optional, Type, TypeVar
+from typing import Any, Generic, Iterable, Optional, Set, Type, TypeVar
+from warnings import warn
 
 import attr
 
 from web_poet._typing import get_item_cls
-from web_poet.fields import FieldsMixin, SelectFields, get_fields_dict, item_from_fields
+from web_poet.fields import (
+    FieldsMixin,
+    SelectFields,
+    UnknownFieldActions,
+    get_fields_dict,
+    item_from_fields,
+)
 from web_poet.mixins import ResponseShortcutsMixin
 from web_poet.page_inputs import HttpResponse
-from web_poet.utils import _create_deprecated_class
+from web_poet.utils import _create_deprecated_class, get_fq_class_name
 
 
 class Injectable(abc.ABC, FieldsMixin):
@@ -72,16 +79,7 @@ class ItemPage(Injectable, Returns[ItemT]):
             self, item_cls=self.item_cls, skip_nonitem_fields=self._skip_nonitem_fields
         )
 
-    # TODO: cache, or maybe not? since users could swap the select_field to
-    # reuse the same instance.
     def _get_select_fields(self) -> Optional[SelectFields]:
-        # TODO: Should we support other naming conventions? this means we need
-        # to iterate over all instance attributes to see if there's an instance
-        # of SelectFields. But this should also mean we need to check if there
-        # are multiple SelectField instances.
-        #
-        # for key, param in inspect.signature(self.__init__).parameters.items():
-
         select_fields = getattr(self, "select_fields", None)
         if not select_fields:
             return None
@@ -92,28 +90,46 @@ class ItemPage(Injectable, Returns[ItemT]):
         return select_fields
 
     @property
-    def fields_to_extract(self) -> Optional[Iterable[str]]:
+    def fields_to_extract(self) -> Iterable[str]:
         """Returns an Iterable of field names which should populate the designated
         ``item_cls``.
 
-        This takes into account the ``include`` and ``excluded`` fields, if
-        :class:`web_poet.fields.SelectFields` is available as an instance
-        attribute to the page object.
+        If :class:`web_poet.fields.SelectFields` is set, this takes into account
+        the fields that are marked as included or excluded alongside any field
+        that are marked as enabled/disabled by default.
         """
         select_fields = self._get_select_fields()
         if select_fields is None:
-            return None
+            return list(get_fields_dict(self))
 
-        if isinstance(select_fields.include, list) and len(select_fields.include) == 0:
-            return set()
+        fields = select_fields.fields
 
-        page_obj_fields = get_fields_dict(self).keys()
-        fields = (set(select_fields.include or []) or page_obj_fields) - set(
-            select_fields.exclude or []
-        )
-        return fields
+        if fields is None or len(fields) == 0:
+            return list(get_fields_dict(self))
+
+        page_obj_fields = get_fields_dict(self, include_disabled=True)
+
+        unknown_fields = set(fields) - set(page_obj_fields.keys()).union({"*"})
+        if unknown_fields:
+            self._handle_unknown_field(unknown_fields, select_fields.on_unknown_field)
+
+        fields_to_extract = []
+        for name, field_info in page_obj_fields.items():
+            if fields.get("*") is False and fields.get(name) is not True:
+                continue
+            if (
+                fields.get("*") is True
+                or fields.get(name) is True
+                or field_info.disabled is False
+            ) and fields.get(name) is not False:
+                fields_to_extract.append(name)
+
+        return fields_to_extract
 
     async def _partial_item(self) -> Optional[Any]:
+        """This only creates a partial item when the ``SelectField`` is set in
+        the page object.
+        """
         select_fields = self._get_select_fields()
         if not select_fields:
             return None
@@ -123,8 +139,28 @@ class ItemPage(Injectable, Returns[ItemT]):
             item_cls=self.item_cls,
             skip_nonitem_fields=self._skip_nonitem_fields,
             field_names=self.fields_to_extract,
-            on_unknown_field=select_fields.on_unknown_field,
         )
+
+    def _handle_unknown_field(
+        self, name: Set[str], action: UnknownFieldActions = "raise"
+    ) -> None:
+        if action == "ignore":
+            return None
+
+        msg = (
+            f"The {name} fields isn't available in {get_fq_class_name(self.__class__)}."
+        )
+
+        if action == "raise":
+            raise AttributeError(msg)
+        elif action == "warn":
+            warn(msg)
+        else:
+            raise ValueError(
+                f"web_poet.SelectFields only accepts 'ignore', 'warn', and 'raise' "
+                f"values. Received unrecognized '{action}' value which it treats as "
+                f"'ignore'."
+            )
 
 
 @attr.s(auto_attribs=True)

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -138,12 +138,6 @@ class ItemPage(Injectable, Returns[ItemT]):
             raise AttributeError(msg)
         elif action == "warn":
             warn(msg)
-        else:
-            raise ValueError(
-                f"web_poet.SelectFields only accepts 'ignore', 'warn', and 'raise' "
-                f"values. Received unrecognized '{action}' value which it treats as "
-                f"'ignore'."
-            )
 
 
 @attr.s(auto_attribs=True)


### PR DESCRIPTION
This is related to #115 which implements [approach 3](https://github.com/scrapinghub/web-poet/issues/115#issuecomment-1408526596).

`swap_item_cls` is omitted for now to reduce its complexity. We can add it later.

### TODO:

*    [ ]  docs
*    [ ]  changelog