### PR TITLE
bump black and isort versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,13 @@ repos:
         language_version: python3
         exclude: ^docs/tutorial-project/
     repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 22.12.0
   - hooks:
       - id: isort
         language_version: python3
         exclude: ^docs/tutorial-project/
     repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.5
   - hooks:
       - id: flake8
         language_version: python3


### PR DESCRIPTION
Similar to scrapinghub/scrapy-poet@140239a which fixes the broken "linters" tox CI.