### PR TITLE
Indent content of HttpResponse-other.json

### DIFF
--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -66,7 +66,12 @@ def test_serialization(book_list_html_response) -> None:
     url = ResponseUrl(url_str)
 
     serialized_deps = serialize([book_list_html_response, url])
-    other_json = f'{{"_encoding": "utf-8", "headers": [], "status": null, "url": "{url_str}"}}'.encode()
+    other_json = f"""{{
+  "_encoding": "utf-8",
+  "headers": [],
+  "status": null,
+  "url": "{url_str}"
+}}""".encode()
     assert serialized_deps == {
         "HttpResponse": {
             "body.html": bytes(book_list_html_response.body),

--- a/web_poet/serialization/functions.py
+++ b/web_poet/serialization/functions.py
@@ -16,7 +16,7 @@ def _serialize_HttpResponse(o: HttpResponse) -> SerializedLeafData:
     return {
         "body.html": bytes(o.body),
         "other.json": json.dumps(
-            other_data, ensure_ascii=False, sort_keys=True
+            other_data, ensure_ascii=False, sort_keys=True, indent=2
         ).encode(),
     }
 


### PR DESCRIPTION
It seems that without indenting "headers" field make HttpResponse-other.json quite unreadable in practice.  