### PR TITLE
Improve the warning raised in case of duplicate rules

### DIFF
--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -374,13 +374,9 @@ def test_add_rule() -> None:
         instead_of=POTopLevelOverriden2,
         to_return=Product,
     )
-    # Since we're using f-strings to compare the warning emitted, don't use
-    # ``pytest.warns()`` here since it treats the msg as regex which translates
-    # the "(" and ")" characters differently from the expected message.
-    with warnings.catch_warnings(record=True) as warnings_emitted:
+    with pytest.warns(UserWarning, match="conflicting rules"):
         registry.add_rule(rule_3)
-    expected_msg = f"Consider updating the priority of these rules: {[rule_1, rule_3]}."
-    assert any([True for w in warnings_emitted if expected_msg in str(w.message)])
+
     assert registry.get_rules() == [rule_1, rule_2, rule_3]
 
 


### PR DESCRIPTION
I noticed it when running our testing suite. The warning before:

```
web_poet/rules.py:171
  /Users/kmike/svn/web-poet/web_poet/rules.py:171: UserWarning: Similar URL patterns [Patterns(include=('example.com',), exclude=(), priority=500), Patterns(include=('example.com',), exclude=(), priority=500)] were declared earlier that use to_return=<class 'tests.po_lib_to_return.ProductSimilar'>. The first, highest-priority rule added to the registry will be used when matching against URLs. Consider updating the priority of these rules: [ApplyRule(for_patterns=Patterns(include=('example.com',), exclude=(), priority=500), use=<class 'tests.po_lib_to_return.SimilarProductPage'>, instead_of=<class 'tests.po_lib_to_return.ProductPage'>, to_return=<class 'tests.po_lib_to_return.ProductSimilar'>, meta={}), ApplyRule(for_patterns=Patterns(include=('example.com',), exclude=(), priority=500), use=<class 'tests.po_lib_to_return.CustomProductPage'>, instead_of=<class 'tests.po_lib_to_return.ProductPage'>, to_return=<class 'tests.po_lib_to_return.ProductSimilar'>, meta={}), ApplyRule(for_patterns=Patterns(include=('example.com',), exclude=(), priority=500), use=<class 'tests.po_lib_to_return.SimilarProductPage'>, instead_of=<class 'tests.po_lib_to_return.ProductPage'>, to_return=<class 'tests.po_lib_to_return.ProductSimilar'>, meta={}), ApplyRule(for_patterns=Patterns(include=('example.com',), exclude=(), priority=500), use=<class 'tests.po_lib_to_return.CustomProductPage'>, instead_of=<class 'tests.po_lib_to_return.ProductPage'>, to_return=<class 'tests.po_lib_to_return.ProductSimilar'>, meta={}), ApplyRule(for_patterns=Patterns(include=('example.com',), exclude=(), priority=500), use=<class 'tests.po_lib_to_return.CustomProductPageNoReturns'>, instead_of=<class 'tests.po_lib_to_return.ProductPage'>, to_return=<class 'tests.po_lib_to_return.ProductSimilar'>, meta={})].
```

After:

```
tests/po_lib_to_return/__init__.py:162
  /Users/kmike/svn/web-poet/tests/po_lib_to_return/__init__.py:162: UserWarning: The registry contains 3 conflicting rules with to_return=<class 'tests.po_lib_to_return.ProductSimilar'> and the same URL pattern:

  Patterns(include=('example.com',), exclude=(), priority=500)

  The first rule added to the registry is used when the URL patterns are the same and the priorities are equal; other rules are ignored. This is error-prone. Consider setting the priority explicitly for these rules:

  ApplyRule(for_patterns=Patterns(include=('example.com',), exclude=(), priority=500), use=<class 'tests.po_lib_to_return.SimilarProductPage'>, instead_of=<class 'tests.po_lib_to_return.ProductPage'>, to_return=<class 'tests.po_lib_to_return.ProductSimilar'>, meta={})
  ApplyRule(for_patterns=Patterns(include=('example.com',), exclude=(), priority=500), use=<class 'tests.po_lib_to_return.CustomProductPage'>, instead_of=<class 'tests.po_lib_to_return.ProductPage'>, to_return=<class 'tests.po_lib_to_return.ProductSimilar'>, meta={})
  ApplyRule(for_patterns=Patterns(include=('example.com',), exclude=(), priority=500), use=<class 'tests.po_lib_to_return.CustomProductPageNoReturns'>, instead_of=<class 'tests.po_lib_to_return.ProductPage'>, to_return=<class 'tests.po_lib_to_return.ProductSimilar'>, meta={})
    class CustomProductPageNoReturns(ProductPage):
```
