### PR TITLE
Add saving/loading of HttpClient responses

### DIFF
--- a/docs/page-objects/testing.rst
+++ b/docs/page-objects/testing.rst
@@ -63,6 +63,13 @@ it, that contains data for Page Object inputs and output::
         │   └── output.json
         └─── test-2
             ├── inputs
+            │   ├── HttpClient-0-HttpRequest.info.json
+            │   ├── HttpClient-0-HttpResponse.body.html
+            │   ├── HttpClient-0-HttpResponse.info.json
+            │   ├── HttpClient-1-HttpRequest.body.txt
+            │   ├── HttpClient-1-HttpRequest.info.json
+            │   ├── HttpClient-1-HttpResponse.body.html
+            │   ├── HttpClient-1-HttpResponse.info.json
             │   ├── HttpResponse-body.html
             │   ├── HttpResponse-info.json
             │   └── ResponseUrl.txt

--- a/docs/page-objects/testing.rst
+++ b/docs/page-objects/testing.rst
@@ -202,3 +202,24 @@ Please also check the official Git LFS documentation for more information.
 
 .. _Git LFS: https://git-lfs.com/
 .. _implementations: https://github.com/git-lfs/git-lfs/wiki/Implementations
+
+Additional requests support
+===========================
+
+If the page object uses the :class:`~.HttpClient` dependency to make
+:ref:`additional requests <additional-requests>`, the generated fixtures will
+contain these requests and their responses. When the test runs,
+:class:`~.HttpClient` will return the saved responses without doing actual
+requests.
+
+Currently requests are compared by their URL, method, headers and body, so if a
+page object makes requests that differ between runs, the test won't be able to
+find a saved response and will fail.
+
+Test coverage
+=============
+
+The coverage for page object code is reported correctly if tools such as
+`coverage`_ are used when running web-poet tests.
+
+.. _coverage: https://coverage.readthedocs.io/

--- a/docs/page-objects/testing.rst
+++ b/docs/page-objects/testing.rst
@@ -57,14 +57,14 @@ it, that contains data for Page Object inputs and output::
         ├── test-1
         │   ├── inputs
         │   │   ├── HttpResponse-body.html
-        │   │   ├── HttpResponse-other.json
+        │   │   ├── HttpResponse-info.json
         │   │   └── ResponseUrl.txt
         │   ├── meta.json
         │   └── output.json
         └─── test-2
             ├── inputs
             │   ├── HttpResponse-body.html
-            │   ├── HttpResponse-other.json
+            │   ├── HttpResponse-info.json
             │   └── ResponseUrl.txt
             ├── meta.json
             └── output.json

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -66,7 +66,7 @@ def test_serialization(book_list_html_response) -> None:
     url = ResponseUrl(url_str)
 
     serialized_deps = serialize([book_list_html_response, url])
-    other_json = f"""{{
+    info_json = f"""{{
   "_encoding": "utf-8",
   "headers": [],
   "status": null,
@@ -75,7 +75,7 @@ def test_serialization(book_list_html_response) -> None:
     assert serialized_deps == {
         "HttpResponse": {
             "body.html": bytes(book_list_html_response.body),
-            "other.json": other_json,
+            "info.json": info_json,
         },
         "ResponseUrl": {
             "txt": url_str.encode(),
@@ -147,7 +147,7 @@ def test_write_data(book_list_html_response, tmp_path) -> None:
     assert (directory / "HttpResponse-body.html").read_bytes() == bytes(
         book_list_html_response.body
     )
-    assert (directory / "HttpResponse-other.json").exists()
+    assert (directory / "HttpResponse-info.json").exists()
     assert (directory / "ResponseUrl.txt").exists()
     assert (directory / "ResponseUrl.txt").read_text(
         encoding="utf-8"

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -177,17 +177,19 @@ def _get_fp_for_url(url: str) -> str:
 
 
 def test_httpclient(pytester, book_list_html_response) -> None:
-    client = HttpClient()
     body1 = HttpResponseBody(b"body1")
     url1 = "http://books.toscrape.com/1.html"
     response1 = HttpResponse(url=url1, body=body1, encoding="utf-8")
     fp1 = _get_fp_for_url(url1)
-    client.saved_responses[fp1] = response1
     body2 = HttpResponseBody(b"body2")
     url2 = "http://books.toscrape.com/2.html"
     response2 = HttpResponse(url=url2, body=body2, encoding="utf-8")
     fp2 = _get_fp_for_url(url2)
-    client.saved_responses[fp2] = response2
+    responses = {
+        fp1: response1,
+        fp2: response2,
+    }
+    client = HttpClient(responses=responses)
 
     base_dir = pytester.path / "fixtures" / get_fq_class_name(ClientPage)
     item = {

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -30,7 +30,7 @@ def test_save_fixture(book_list_html_response, tmp_path) -> None:
         assert (input_dir / "HttpResponse-body.html").read_bytes() == bytes(
             book_list_html_response.body
         )
-        assert (input_dir / "HttpResponse-other.json").exists()
+        assert (input_dir / "HttpResponse-info.json").exists()
         assert (directory / OUTPUT_FILE_NAME).exists()
         assert json.loads((directory / OUTPUT_FILE_NAME).read_bytes()) == item
         if expected_meta:
@@ -195,8 +195,8 @@ def test_httpclient(pytester, book_list_html_response) -> None:
     assert (input_dir / "HttpResponse-body.html").read_bytes() == bytes(
         book_list_html_response.body
     )
-    assert (input_dir / "HttpClient-0-HttpRequest.other.json").exists()
-    assert (input_dir / "HttpClient-0-HttpResponse.other.json").exists()
+    assert (input_dir / "HttpClient-0-HttpRequest.info.json").exists()
+    assert (input_dir / "HttpClient-0-HttpResponse.info.json").exists()
     assert (input_dir / "HttpClient-0-HttpResponse.body.html").read_bytes() == bytes(
         body1
     )

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -12,6 +12,7 @@ from itemadapter import ItemAdapter
 from zyte_common_items import Item, Metadata, Product
 
 from web_poet import HttpClient, HttpRequest, HttpResponse, WebPage
+from web_poet.page_inputs.client import SavedResponseData
 from web_poet.testing import Fixture
 from web_poet.testing.fixture import INPUT_DIR_NAME, META_FILE_NAME, OUTPUT_FILE_NAME
 from web_poet.utils import get_fq_class_name
@@ -264,8 +265,8 @@ def test_httpclient(pytester, book_list_html_response) -> None:
     request2 = HttpRequest(url2, method="POST", body=b"post")
     response2 = HttpResponse(url=url2, body=b"body2", encoding="utf-8")
     responses = [
-        (request1, response1),
-        (request2, response2),
+        SavedResponseData(request1, response1),
+        SavedResponseData(request2, response2),
     ]
     client = HttpClient(responses=responses)
 
@@ -292,7 +293,7 @@ def test_httpclient_no_response(pytester, book_list_html_response) -> None:
     request = HttpRequest(url)
     response = HttpResponse(url=url, body=b"body1", encoding="utf-8")
     responses = [
-        (request, response),
+        SavedResponseData(request, response),
     ]
     client = HttpClient(responses=responses)
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -284,7 +284,7 @@ def test_httpclient(pytester, book_list_html_response) -> None:
     assert (input_dir / "HttpClient-0-HttpResponse.body.html").read_bytes() == b"body1"
     assert (input_dir / "HttpClient-1-HttpResponse.body.html").read_bytes() == b"body2"
     result = pytester.runpytest()
-    result.assert_outcomes(passed=1)
+    result.assert_outcomes(passed=3)
 
 
 def test_httpclient_no_response(pytester, book_list_html_response) -> None:
@@ -303,4 +303,4 @@ def test_httpclient_no_response(pytester, book_list_html_response) -> None:
     }
     Fixture.save(base_dir, inputs=[book_list_html_response, client], item=item)
     result = pytester.runpytest()
-    result.assert_outcomes(failed=1)
+    result.assert_outcomes(failed=3)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -11,7 +11,7 @@ import time_machine
 from itemadapter import ItemAdapter
 from zyte_common_items import Item, Metadata, Product
 
-from web_poet import HttpClient, HttpRequest, HttpResponse, HttpResponseBody, WebPage
+from web_poet import HttpClient, HttpRequest, HttpResponse, WebPage
 from web_poet.testing import Fixture
 from web_poet.testing.fixture import INPUT_DIR_NAME, META_FILE_NAME, OUTPUT_FILE_NAME
 from web_poet.utils import get_fq_class_name
@@ -171,14 +171,12 @@ class ClientPage(WebPage):
 
 
 def test_httpclient(pytester, book_list_html_response) -> None:
-    body1 = HttpResponseBody(b"body1")
     url1 = "http://books.toscrape.com/1.html"
     request1 = HttpRequest(url1)
-    response1 = HttpResponse(url=url1, body=body1, encoding="utf-8")
-    body2 = HttpResponseBody(b"body2")
+    response1 = HttpResponse(url=url1, body=b"body1", encoding="utf-8")
     url2 = "http://books.toscrape.com/2.html"
     request2 = HttpRequest(url2)
-    response2 = HttpResponse(url=url2, body=body2, encoding="utf-8")
+    response2 = HttpResponse(url=url2, body=b"body2", encoding="utf-8")
     responses = [
         (request1, response1),
         (request2, response2),
@@ -197,23 +195,18 @@ def test_httpclient(pytester, book_list_html_response) -> None:
     )
     assert (input_dir / "HttpClient-0-HttpRequest.info.json").exists()
     assert (input_dir / "HttpClient-0-HttpResponse.info.json").exists()
-    assert (input_dir / "HttpClient-0-HttpResponse.body.html").read_bytes() == bytes(
-        body1
-    )
-    assert (input_dir / "HttpClient-1-HttpResponse.body.html").read_bytes() == bytes(
-        body2
-    )
+    assert (input_dir / "HttpClient-0-HttpResponse.body.html").read_bytes() == b"body1"
+    assert (input_dir / "HttpClient-1-HttpResponse.body.html").read_bytes() == b"body2"
     result = pytester.runpytest()
     result.assert_outcomes(passed=1)
 
 
 def test_httpclient_no_response(pytester, book_list_html_response) -> None:
-    body1 = HttpResponseBody(b"body1")
-    url1 = "http://books.toscrape.com/1.html"
-    request1 = HttpRequest(url1)
-    response1 = HttpResponse(url=url1, body=body1, encoding="utf-8")
+    url = "http://books.toscrape.com/1.html"
+    request = HttpRequest(url)
+    response = HttpResponse(url=url, body=b"body1", encoding="utf-8")
     responses = [
-        (request1, response1),
+        (request, response),
     ]
     client = HttpClient(responses=responses)
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -12,6 +12,7 @@ from itemadapter import ItemAdapter
 from zyte_common_items import Item, Metadata, Product
 
 from web_poet import HttpClient, HttpRequest, HttpResponse, HttpResponseBody, WebPage
+from web_poet.page_inputs.http import request_fingerprint
 from web_poet.testing import Fixture
 from web_poet.testing.fixture import INPUT_DIR_NAME, META_FILE_NAME, OUTPUT_FILE_NAME
 from web_poet.utils import get_fq_class_name
@@ -172,10 +173,10 @@ class ClientPage(WebPage):
 
 def _get_fp_for_url(url: str) -> str:
     req = HttpRequest(url=url)
-    return req.fingerprint()
+    return request_fingerprint(req)
 
 
-def test_httpclient_serialize(pytester, book_list_html_response) -> None:
+def test_httpclient(pytester, book_list_html_response) -> None:
     client = HttpClient()
     body1 = HttpResponseBody(b"body1")
     url1 = "http://books.toscrape.com/1.html"

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -205,3 +205,23 @@ def test_httpclient(pytester, book_list_html_response) -> None:
     )
     result = pytester.runpytest()
     result.assert_outcomes(passed=1)
+
+
+def test_httpclient_no_response(pytester, book_list_html_response) -> None:
+    body1 = HttpResponseBody(b"body1")
+    url1 = "http://books.toscrape.com/1.html"
+    request1 = HttpRequest(url1)
+    response1 = HttpResponse(url=url1, body=body1, encoding="utf-8")
+    responses = [
+        (request1, response1),
+    ]
+    client = HttpClient(responses=responses)
+
+    base_dir = pytester.path / "fixtures" / get_fq_class_name(ClientPage)
+    item = {
+        "foo": "bar",
+        "additional": ["body1", "body2"],
+    }
+    Fixture.save(base_dir, inputs=[book_list_html_response, client], item=item)
+    result = pytester.runpytest()
+    result.assert_outcomes(failed=1)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -296,11 +296,15 @@ def test_httpclient_no_response(pytester, book_list_html_response) -> None:
     ]
     client = HttpClient(responses=responses)
 
-    base_dir = pytester.path / "fixtures" / get_fq_class_name(ClientPage)
     item = {
         "foo": "bar",
         "additional": ["body1", "body2"],
     }
-    Fixture.save(base_dir, inputs=[book_list_html_response, client], item=item)
+    _save_fixture(
+        pytester,
+        page_cls=ClientPage,
+        page_inputs=[book_list_html_response, client],
+        expected=item,
+    )
     result = pytester.runpytest()
     result.assert_outcomes(failed=3)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -13,7 +13,7 @@ from zyte_common_items import Item, Metadata, Product
 
 from web_poet import HttpClient, HttpRequest, HttpResponse, WebPage
 from web_poet.exceptions import HttpResponseError
-from web_poet.page_inputs.client import SavedResponseData
+from web_poet.page_inputs.client import _SavedResponseData
 from web_poet.testing import Fixture
 from web_poet.testing.fixture import INPUT_DIR_NAME, META_FILE_NAME, OUTPUT_FILE_NAME
 from web_poet.utils import get_fq_class_name
@@ -266,8 +266,8 @@ def test_httpclient(pytester, book_list_html_response) -> None:
     request2 = HttpRequest(url2, method="POST", body=b"post")
     response2 = HttpResponse(url=url2, body=b"body2", encoding="utf-8")
     responses = [
-        SavedResponseData(request1, response1),
-        SavedResponseData(request2, response2),
+        _SavedResponseData(request1, response1),
+        _SavedResponseData(request2, response2),
     ]
     client = HttpClient(responses=responses)
 
@@ -294,7 +294,7 @@ def test_httpclient_no_response(pytester, book_list_html_response) -> None:
     request = HttpRequest(url)
     response = HttpResponse(url=url, body=b"body1", encoding="utf-8")
     responses = [
-        SavedResponseData(request, response),
+        _SavedResponseData(request, response),
     ]
     client = HttpClient(responses=responses)
 
@@ -330,7 +330,7 @@ def test_httpclient_exception(pytester, book_list_html_response) -> None:
     request = HttpRequest(url)
     response = HttpResponse(url=url, body=b"body1", status=404, encoding="utf-8")
     responses = [
-        SavedResponseData(request, response),
+        _SavedResponseData(request, response),
     ]
     client = HttpClient(responses=responses)
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -252,7 +252,7 @@ class ClientPage(WebPage):
 
     async def to_item(self) -> dict:  # noqa: D102
         resp1 = await self.client.get("http://books.toscrape.com/1.html")
-        resp2 = await self.client.get("http://books.toscrape.com/2.html")
+        resp2 = await self.client.post("http://books.toscrape.com/2.html", body=b"post")
         return {"foo": "bar", "additional": [resp1.body.decode(), resp2.body.decode()]}
 
 
@@ -261,7 +261,7 @@ def test_httpclient(pytester, book_list_html_response) -> None:
     request1 = HttpRequest(url1)
     response1 = HttpResponse(url=url1, body=b"body1", encoding="utf-8")
     url2 = "http://books.toscrape.com/2.html"
-    request2 = HttpRequest(url2)
+    request2 = HttpRequest(url2, method="POST", body=b"post")
     response2 = HttpResponse(url=url2, body=b"body2", encoding="utf-8")
     responses = [
         (request1, response1),

--- a/web_poet/exceptions/core.py
+++ b/web_poet/exceptions/core.py
@@ -5,6 +5,17 @@ Core Exceptions
 These exceptions are tied to how **web-poet** operates.
 """
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from web_poet import HttpRequest
+
+
+__all__ = [
+    "RequestDownloaderVarError",
+    "Retry",
+]
+
 
 class RequestDownloaderVarError(Exception):
     """The ``web_poet.request_downloader_var`` had its contents accessed but there
@@ -25,3 +36,20 @@ class Retry(ValueError):
     """
 
     pass
+
+
+class NoSavedHttpResponse(AssertionError):
+    """Indicates that there is no saved response for this request.
+
+    Can only be raised when a :class:`~.HttpClient` instance is used to
+    get saved responses.
+
+    :param request: The :class:`~.HttpRequest` instance that was used.
+    :type request: HttpRequest
+    """
+
+    def __init__(self, msg: str = None, request: "HttpRequest" = None):
+        self.request = request
+        if msg is None:
+            msg = f"There is no saved response available for this HTTP Request: {self.request}"
+        super().__init__(msg)

--- a/web_poet/exceptions/http.py
+++ b/web_poet/exceptions/http.py
@@ -73,20 +73,3 @@ class HttpResponseError(HttpError):
         if msg is None:
             msg = f"Unexpected HTTP Response received: {self.response}"
         super().__init__(msg, request=request)
-
-
-class NoSavedHttpResponse(HttpError):
-    """Indicates that there is no saved response for this request.
-
-    Can only be raised when a :class:`~.HttpClient` instance is used to
-    get saved responses.
-
-    :param request: The :class:`~.HttpRequest` instance that was used.
-    :type request: HttpRequest
-    """
-
-    def __init__(self, msg: str = None, request: HttpRequest = None):
-        self.request = request
-        if msg is None:
-            msg = f"There is no saved response available for this HTTP Request: {self.request}"
-        super().__init__(msg)

--- a/web_poet/exceptions/http.py
+++ b/web_poet/exceptions/http.py
@@ -88,5 +88,5 @@ class NoSavedHttpResponse(HttpError):
     def __init__(self, msg: str = None, request: HttpRequest = None):
         self.request = request
         if msg is None:
-            msg = f"There is no saved reponse available for this HTTP Request: {self.request}"
+            msg = f"There is no saved response available for this HTTP Request: {self.request}"
         super().__init__(msg)

--- a/web_poet/exceptions/http.py
+++ b/web_poet/exceptions/http.py
@@ -73,3 +73,20 @@ class HttpResponseError(HttpError):
         if msg is None:
             msg = f"Unexpected HTTP Response received: {self.response}"
         super().__init__(msg, request=request)
+
+
+class NoSavedHttpResponse(HttpError):
+    """Indicates that there is no saved response for this request.
+
+    Can only be raised when a :class:`~.HttpClient` instance is used to
+    get saved responses.
+
+    :param request: The :class:`~.HttpRequest` instance that was used.
+    :type request: HttpRequest
+    """
+
+    def __init__(self, msg: str = None, request: HttpRequest = None):
+        self.request = request
+        if msg is None:
+            msg = f"There is no saved reponse available for this HTTP Request: {self.request}"
+        super().__init__(msg)

--- a/web_poet/page_inputs/client.py
+++ b/web_poet/page_inputs/client.py
@@ -46,11 +46,12 @@ class HttpClient:
         *,
         save_responses: bool = False,
         return_only_saved_responses: bool = False,
+        responses: Optional[Dict[str, HttpResponse]] = None,
     ):
         self._request_downloader = request_downloader or _perform_request
         self.save_responses = save_responses
         self.return_only_saved_responses = return_only_saved_responses
-        self.saved_responses: Dict[str, HttpResponse] = {}
+        self.saved_responses: Dict[str, HttpResponse] = responses or {}
 
     @staticmethod
     def _handle_status(

--- a/web_poet/page_inputs/client.py
+++ b/web_poet/page_inputs/client.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass
 from http import HTTPStatus
 from typing import Callable, Dict, Iterable, List, Optional, Union
 
-from web_poet.exceptions import HttpResponseError, NoSavedHttpResponse
+from web_poet.exceptions import HttpResponseError
+from web_poet.exceptions.core import NoSavedHttpResponse
 from web_poet.page_inputs.http import (
     HttpRequest,
     HttpRequestBody,

--- a/web_poet/page_inputs/client.py
+++ b/web_poet/page_inputs/client.py
@@ -194,15 +194,20 @@ class HttpClient:
         if self.return_only_saved_responses:
             for fp, saved_data in self._saved_responses.items():
                 if request_fingerprint(request) == fp:
+                    self._handle_status(
+                        saved_data.response,
+                        saved_data.request,
+                        allow_status=allow_status,
+                    )
                     return saved_data.response
             raise NoSavedHttpResponse(request=request)
 
         response = await self._request_downloader(request)
-        self._handle_status(response, request, allow_status=allow_status)
         if self.save_responses:
             self._saved_responses[request_fingerprint(request)] = SavedResponseData(
                 request, response
             )
+        self._handle_status(response, request, allow_status=allow_status)
         return response
 
     async def batch_execute(

--- a/web_poet/page_inputs/client.py
+++ b/web_poet/page_inputs/client.py
@@ -3,7 +3,7 @@ import logging
 from http import HTTPStatus
 from typing import Callable, Dict, List, Optional, Union
 
-from web_poet.exceptions import HttpResponseError
+from web_poet.exceptions import HttpResponseError, NoSavedHttpResponse
 from web_poet.page_inputs.http import (
     HttpRequest,
     HttpRequestBody,
@@ -180,7 +180,7 @@ class HttpClient:
             saved_response = self.saved_responses.get(request_fingerprint(request))
             if saved_response:
                 return saved_response
-            raise ValueError(f"No saved response for {request}")
+            raise NoSavedHttpResponse(request=request)
 
         response = await self._request_downloader(request)
         self._handle_status(response, request, allow_status=allow_status)

--- a/web_poet/page_inputs/client.py
+++ b/web_poet/page_inputs/client.py
@@ -26,7 +26,7 @@ _StatusList = Union[str, int, List[Union[str, int]]]
 
 
 @dataclass
-class SavedResponseData:
+class _SavedResponseData:
     """Class for storing a request and its result."""
 
     request: HttpRequest
@@ -60,12 +60,12 @@ class HttpClient:
         *,
         save_responses: bool = False,
         return_only_saved_responses: bool = False,
-        responses: Optional[Iterable[SavedResponseData]] = None,
+        responses: Optional[Iterable[_SavedResponseData]] = None,
     ):
         self._request_downloader = request_downloader or _perform_request
         self.save_responses = save_responses
         self.return_only_saved_responses = return_only_saved_responses
-        self._saved_responses: Dict[str, SavedResponseData] = {
+        self._saved_responses: Dict[str, _SavedResponseData] = {
             data.fingerprint(): data for data in responses or []
         }
 
@@ -205,7 +205,7 @@ class HttpClient:
 
         response = await self._request_downloader(request)
         if self.save_responses:
-            self._saved_responses[request_fingerprint(request)] = SavedResponseData(
+            self._saved_responses[request_fingerprint(request)] = _SavedResponseData(
                 request, response
             )
         self._handle_status(response, request, allow_status=allow_status)
@@ -250,6 +250,6 @@ class HttpClient:
         )
         return responses
 
-    def get_saved_responses(self) -> Iterable[SavedResponseData]:
+    def get_saved_responses(self) -> Iterable[_SavedResponseData]:
         """Return saved requests and responses."""
         return self._saved_responses.values()

--- a/web_poet/page_inputs/client.py
+++ b/web_poet/page_inputs/client.py
@@ -187,7 +187,6 @@ class HttpClient:
         response = await self._request_downloader(request)
         self._handle_status(response, request, allow_status=allow_status)
         if self.save_responses:
-            # TODO: copy()?
             self._saved_responses[request_fingerprint(request)] = (request, response)
         return response
 

--- a/web_poet/page_inputs/client.py
+++ b/web_poet/page_inputs/client.py
@@ -9,6 +9,7 @@ from web_poet.page_inputs.http import (
     HttpRequestBody,
     HttpRequestHeaders,
     HttpResponse,
+    request_fingerprint,
 )
 from web_poet.page_inputs.url import _Url
 from web_poet.requests import _perform_request
@@ -174,7 +175,7 @@ class HttpClient:
         There is no need to include ``100-3xx`` status codes in ``allow_status``,
         because :class:`~.HttpResponseError` is not raised for them.
         """
-        response_key = request.fingerprint()
+        response_key = request_fingerprint(request)
         if self.return_only_saved_responses:
             saved_response = self.saved_responses.get(response_key)
             if saved_response:

--- a/web_poet/page_inputs/client.py
+++ b/web_poet/page_inputs/client.py
@@ -175,16 +175,17 @@ class HttpClient:
         There is no need to include ``100-3xx`` status codes in ``allow_status``,
         because :class:`~.HttpResponseError` is not raised for them.
         """
-        response_key = request_fingerprint(request)
         if self.return_only_saved_responses:
-            saved_response = self.saved_responses.get(response_key)
+            saved_response = self.saved_responses.get(request_fingerprint(request))
             if saved_response:
                 return saved_response
             raise ValueError(f"No saved response for {request}")
+
         response = await self._request_downloader(request)
         self._handle_status(response, request, allow_status=allow_status)
         if self.save_responses:
-            self.saved_responses[response_key] = response  # TODO: copy()?
+            # TODO: copy()?
+            self.saved_responses[request_fingerprint(request)] = response
         return response
 
     async def batch_execute(

--- a/web_poet/page_inputs/http.py
+++ b/web_poet/page_inputs/http.py
@@ -309,7 +309,7 @@ def request_fingerprint(req: HttpRequest) -> str:
     fp = sha1()
     fp.update(req.method.encode() + b"\n")
     fp.update(canonicalize_url(str(req.url)).encode())
-    fp.update(str(req.url).encode() + b"\n")
     for name, value in sorted(req.headers.items()):
         fp.update(f"{name}:{value}\n".encode())
+    fp.update(req.body)
     return fp.hexdigest()

--- a/web_poet/page_inputs/http.py
+++ b/web_poet/page_inputs/http.py
@@ -310,6 +310,6 @@ def request_fingerprint(req: HttpRequest) -> str:
     fp.update(req.method.encode() + b"\n")
     fp.update(canonicalize_url(str(req.url)).encode())
     for name, value in sorted(req.headers.items()):
-        fp.update(f"{name}:{value}\n".encode())
+        fp.update(f"{name.title()}:{value}\n".encode())
     fp.update(req.body)
     return fp.hexdigest()

--- a/web_poet/page_inputs/http.py
+++ b/web_poet/page_inputs/http.py
@@ -311,5 +311,6 @@ def request_fingerprint(req: HttpRequest) -> str:
     fp.update(canonicalize_url(str(req.url)).encode() + b"\n")
     for name, value in sorted(req.headers.items()):
         fp.update(f"{name.title()}:{value}\n".encode())
-    fp.update(b"\n" + req.body)
+    fp.update(b"\n")
+    fp.update(req.body)
     return fp.hexdigest()

--- a/web_poet/page_inputs/http.py
+++ b/web_poet/page_inputs/http.py
@@ -311,5 +311,5 @@ def request_fingerprint(req: HttpRequest) -> str:
     fp.update(canonicalize_url(str(req.url)).encode() + b"\n")
     for name, value in sorted(req.headers.items()):
         fp.update(f"{name.title()}:{value}\n".encode())
-    fp.update(req.body)
+    fp.update(b"\n" + req.body)
     return fp.hexdigest()

--- a/web_poet/page_inputs/http.py
+++ b/web_poet/page_inputs/http.py
@@ -1,4 +1,5 @@
 import json
+from hashlib import sha1
 from typing import Any, AnyStr, Dict, List, Optional, Tuple, Type, TypeVar, Union
 from urllib.parse import urljoin
 
@@ -180,6 +181,10 @@ class HttpRequest:
 
         If *url* is relative, it is made absolute relative to :attr:`url`."""
         return _RequestUrl(urljoin(str(self.url), str(url)))
+
+    def fingerprint(self) -> str:
+        """Return the fingerprint of this request."""
+        return sha1(str(self.url).encode()).hexdigest()  # TODO
 
 
 @attrs.define(auto_attribs=False, slots=False, eq=False)

--- a/web_poet/page_inputs/http.py
+++ b/web_poet/page_inputs/http.py
@@ -308,7 +308,7 @@ def request_fingerprint(req: HttpRequest) -> str:
     """Return the fingerprint of the request."""
     fp = sha1()
     fp.update(req.method.encode() + b"\n")
-    fp.update(canonicalize_url(str(req.url)).encode())
+    fp.update(canonicalize_url(str(req.url)).encode() + b"\n")
     for name, value in sorted(req.headers.items()):
         fp.update(f"{name.title()}:{value}\n".encode())
     fp.update(req.body)

--- a/web_poet/serialization/functions.py
+++ b/web_poet/serialization/functions.py
@@ -91,12 +91,11 @@ def _deserialize_HttpClient(
         response_key, subkey = k.rsplit("-", 1)
         serialized_responses.setdefault(response_key, {})[subkey] = v
 
-    result = cls(return_only_saved_responses=True)
+    responses: Dict[str, HttpResponse] = {}
     for response_key, serialized_response in serialized_responses.items():
-        result.saved_responses[response_key] = deserialize_leaf(
-            HttpResponse, serialized_response
-        )
-    return result
+        responses[response_key] = deserialize_leaf(HttpResponse, serialized_response)
+
+    return cls(return_only_saved_responses=True, responses=responses)
 
 
 register_serialization(_serialize_HttpClient, _deserialize_HttpClient)

--- a/web_poet/serialization/functions.py
+++ b/web_poet/serialization/functions.py
@@ -1,17 +1,8 @@
 import json
 from typing import Dict, List, Tuple, Type
 
-from .. import (
-    HttpClient,
-    HttpRequest,
-    HttpRequestBody,
-    HttpRequestHeaders,
-    HttpResponse,
-    HttpResponseBody,
-    HttpResponseHeaders,
-    ResponseUrl,
-)
-from ..page_inputs.url import RequestUrl, _Url
+from .. import HttpClient, HttpRequest, HttpRequestBody, HttpResponse, HttpResponseBody
+from ..page_inputs.url import _Url
 from .api import (
     SerializedLeafData,
     deserialize_leaf,
@@ -43,9 +34,9 @@ def _deserialize_HttpRequest(
     other_data = json.loads(data["other.json"])
     return cls(
         body=body,
-        url=RequestUrl(other_data["url"]),
+        url=other_data["url"],
         method=other_data["method"],
-        headers=HttpRequestHeaders(other_data["headers"]),
+        headers=other_data["headers"],
     )
 
 
@@ -74,9 +65,9 @@ def _deserialize_HttpResponse(
     other_data = json.loads(data["other.json"])
     return cls(
         body=body,
-        url=ResponseUrl(other_data["url"]),
+        url=other_data["url"],
         status=other_data["status"],
-        headers=HttpResponseHeaders(other_data["headers"]),
+        headers=other_data["headers"],
         encoding=other_data["_encoding"],
     )
 

--- a/web_poet/serialization/functions.py
+++ b/web_poet/serialization/functions.py
@@ -110,7 +110,7 @@ register_serialization(_serialize__Url, _deserialize__Url)
 
 def _serialize_HttpClient(o: HttpClient) -> SerializedLeafData:
     serialized_data: SerializedLeafData = {}
-    for i, (request, response) in enumerate(o.saved_responses):
+    for i, (request, response) in enumerate(o.get_saved_responses()):
         serialized_request = serialize_leaf(request)
         for k, v in serialized_request.items():
             serialized_data[f"{i}-HttpRequest.{k}"] = v

--- a/web_poet/serialization/functions.py
+++ b/web_poet/serialization/functions.py
@@ -12,14 +12,14 @@ from .api import (
 
 
 def _serialize_HttpRequest(o: HttpRequest) -> SerializedLeafData:
-    other_data = {
+    info = {
         "url": str(o.url),
         "method": o.method,
         "headers": list(o.headers.items()),
     }
     result: SerializedLeafData = {
-        "other.json": json.dumps(
-            other_data, ensure_ascii=False, sort_keys=True, indent=2
+        "info.json": json.dumps(
+            info, ensure_ascii=False, sort_keys=True, indent=2
         ).encode(),
     }
     if o.body:
@@ -31,12 +31,12 @@ def _deserialize_HttpRequest(
     cls: Type[HttpRequest], data: SerializedLeafData
 ) -> HttpRequest:
     body = HttpRequestBody(data.get("body.txt", b""))
-    other_data = json.loads(data["other.json"])
+    info = json.loads(data["info.json"])
     return cls(
         body=body,
-        url=other_data["url"],
-        method=other_data["method"],
-        headers=other_data["headers"],
+        url=info["url"],
+        method=info["method"],
+        headers=info["headers"],
     )
 
 
@@ -44,7 +44,7 @@ register_serialization(_serialize_HttpRequest, _deserialize_HttpRequest)
 
 
 def _serialize_HttpResponse(o: HttpResponse) -> SerializedLeafData:
-    other_data = {
+    info = {
         "url": str(o.url),
         "status": o.status,
         "headers": list(o.headers.items()),
@@ -52,8 +52,8 @@ def _serialize_HttpResponse(o: HttpResponse) -> SerializedLeafData:
     }
     return {
         "body.html": bytes(o.body),
-        "other.json": json.dumps(
-            other_data, ensure_ascii=False, sort_keys=True, indent=2
+        "info.json": json.dumps(
+            info, ensure_ascii=False, sort_keys=True, indent=2
         ).encode(),
     }
 
@@ -62,13 +62,13 @@ def _deserialize_HttpResponse(
     cls: Type[HttpResponse], data: SerializedLeafData
 ) -> HttpResponse:
     body = HttpResponseBody(data["body.html"])
-    other_data = json.loads(data["other.json"])
+    info = json.loads(data["info.json"])
     return cls(
         body=body,
-        url=other_data["url"],
-        status=other_data["status"],
-        headers=other_data["headers"],
-        encoding=other_data["_encoding"],
+        url=info["url"],
+        status=info["status"],
+        headers=info["headers"],
+        encoding=info["_encoding"],
     )
 
 
@@ -119,7 +119,7 @@ def _deserialize_HttpClient(
     serialized_requests: Dict[str, SerializedLeafData] = {}
     serialized_responses: Dict[str, SerializedLeafData] = {}
     for k, v in data.items():
-        # k is number-("HttpRequest"|"HttpResponse").("body"|"other").ext
+        # k is number-("HttpRequest"|"HttpResponse").("body"|"info").ext
         key, type_suffix = k.split("-", 1)
         type_name, suffix = type_suffix.split(".", 1)
         if type_name == "HttpRequest":

--- a/web_poet/serialization/functions.py
+++ b/web_poet/serialization/functions.py
@@ -1,7 +1,8 @@
 import json
-from typing import Dict, List, Tuple, Type
+from typing import Dict, List, Type
 
 from .. import HttpClient, HttpRequest, HttpRequestBody, HttpResponse, HttpResponseBody
+from ..page_inputs.client import SavedResponseData
 from ..page_inputs.url import _Url
 from .api import (
     SerializedLeafData,
@@ -101,11 +102,11 @@ register_serialization(_serialize__Url, _deserialize__Url)
 
 def _serialize_HttpClient(o: HttpClient) -> SerializedLeafData:
     serialized_data: SerializedLeafData = {}
-    for i, (request, response) in enumerate(o.get_saved_responses()):
-        serialized_request = serialize_leaf(request)
+    for i, data in enumerate(o.get_saved_responses()):
+        serialized_request = serialize_leaf(data.request)
         for k, v in serialized_request.items():
             serialized_data[f"{i}-HttpRequest.{k}"] = v
-        serialized_response = serialize_leaf(response)
+        serialized_response = serialize_leaf(data.response)
         for k, v in serialized_response.items():
             serialized_data[f"{i}-HttpResponse.{k}"] = v
     return serialized_data
@@ -114,7 +115,7 @@ def _serialize_HttpClient(o: HttpClient) -> SerializedLeafData:
 def _deserialize_HttpClient(
     cls: Type[HttpClient], data: SerializedLeafData
 ) -> HttpClient:
-    responses: List[Tuple[HttpRequest, HttpResponse]] = []
+    responses: List[SavedResponseData] = []
 
     serialized_requests: Dict[str, SerializedLeafData] = {}
     serialized_responses: Dict[str, SerializedLeafData] = {}
@@ -133,7 +134,7 @@ def _deserialize_HttpClient(
             continue
         request = deserialize_leaf(HttpRequest, serialized_request)
         response = deserialize_leaf(HttpResponse, serialized_response)
-        responses.append((request, response))
+        responses.append(SavedResponseData(request, response))
 
     return cls(return_only_saved_responses=True, responses=responses)
 

--- a/web_poet/serialization/functions.py
+++ b/web_poet/serialization/functions.py
@@ -2,7 +2,7 @@ import json
 from typing import Dict, List, Type
 
 from .. import HttpClient, HttpRequest, HttpRequestBody, HttpResponse, HttpResponseBody
-from ..page_inputs.client import SavedResponseData
+from ..page_inputs.client import _SavedResponseData
 from ..page_inputs.url import _Url
 from .api import (
     SerializedLeafData,
@@ -115,7 +115,7 @@ def _serialize_HttpClient(o: HttpClient) -> SerializedLeafData:
 def _deserialize_HttpClient(
     cls: Type[HttpClient], data: SerializedLeafData
 ) -> HttpClient:
-    responses: List[SavedResponseData] = []
+    responses: List[_SavedResponseData] = []
 
     serialized_requests: Dict[str, SerializedLeafData] = {}
     serialized_responses: Dict[str, SerializedLeafData] = {}
@@ -134,7 +134,7 @@ def _deserialize_HttpClient(
             continue
         request = deserialize_leaf(HttpRequest, serialized_request)
         response = deserialize_leaf(HttpResponse, serialized_response)
-        responses.append(SavedResponseData(request, response))
+        responses.append(_SavedResponseData(request, response))
 
     return cls(return_only_saved_responses=True, responses=responses)
 


### PR DESCRIPTION
This adds two flags to HttpClient: one tells it to save all responses into an attribute, another one tells it to return saved responses if they are available and raise an exception if they are not. It also adds serialization support for HttpClient that saves/restores these responses and sets the second flag on the deserialized HttpClient. I don't currently see how can we set the first flag when we generate a test, maybe it shouldn't be a flag of `__init__` but some other check.

This requires having some fingerprinting code for HttpRequest (the one in this PR is a placeholder). Not sure how comprehensive should it be. The Scrapy one is quite complicated taking into account that URLs can have fragments, not all headers are important etc. The code in scrapy-poet that gets a fingerprint for caching uses the Scrapy code as far as I remember, but here we can't depend on Scrapy. I also wonder if this fingerprinting needs to be user-configurable.