### PR TITLE
support non-ascii output in fixtures

### DIFF
--- a/web_poet/testing/fixture.py
+++ b/web_poet/testing/fixture.py
@@ -211,8 +211,8 @@ class Fixture:
         storage = SerializedDataFileStorage(fixture.input_path)
         storage.write(serialized_inputs)
         with fixture.output_path.open("w") as f:
-            json.dump(ItemAdapter(item).asdict(), f, ensure_ascii=True, indent=4)
+            json.dump(ItemAdapter(item).asdict(), f, ensure_ascii=False, indent=4)
         if meta:
             with fixture.meta_path.open("w") as f:
-                json.dump(meta, f, ensure_ascii=True, indent=4)
+                json.dump(meta, f, ensure_ascii=False, indent=4)
         return fixture


### PR DESCRIPTION
savefixture command currently produces output like

>     "currencyRaw": "\u20ac",

instead of 

>     "currencyRaw": "€",

Is there a particular reason ensure_ascii is set to True?