### PR TITLE
Add support for default item processors

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -505,6 +505,38 @@ async def test_field_processors_async() -> None:
     assert await page.name == "namex"
 
 
+def test_field_processors_default() -> None:
+    def proc1(s):
+        return s + "x"
+
+    @attrs.define
+    class Page(ItemPage):
+        default_processors = [str.strip, proc1]
+
+        @field
+        def name(self):  # noqa: D102
+            return "  name\t "
+
+    page = Page()
+    assert page.name == "namex"
+
+
+def test_field_processors_override_default() -> None:
+    def proc1(s):
+        return s + "x"
+
+    @attrs.define
+    class Page(ItemPage):
+        default_processors = [str.strip]
+
+        @field(out=[proc1])
+        def name(self):  # noqa: D102
+            return "  name\t "
+
+    page = Page()
+    assert page.name == "  name\t x"
+
+
 def test_field_mixin() -> None:
     class A(ItemPage):
         @field


### PR DESCRIPTION
Now if the field doesn't have `out=` specified, the page object attribute named `default_processors` (feel free to propose an alternative name) will be used in the same way as the `out` decorator argument is used. So per-field processors override default ones, not add to it, just like in `itemloaders`. And just like in `itemloaders` you can skip the default processor by passing `out=[Identity()]` (after we add the `Identity` processor somewhere).