### PR TITLE
Another attrs.define fix

### DIFF
--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -62,7 +62,7 @@ class ItemPage(Injectable, Returns[ItemT]):
 
     def _get_skip_nonitem_fields(self) -> bool:
         value = self._skip_nonitem_fields
-        return False if value is _NOT_SET else value
+        return False if value is _NOT_SET else bool(value)
 
     def __init_subclass__(cls, skip_nonitem_fields=_NOT_SET, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -50,32 +50,34 @@ class Returns(typing.Generic[ItemT]):
         return get_item_cls(self.__class__, default=dict)
 
 
+_NOT_SET = object()
+
+
 class ItemPage(Injectable, Returns[ItemT]):
     """Base Page Object, with a default :meth:`to_item` implementation
     which supports web-poet fields.
     """
 
-    __skip_nonitem_fields: bool
-    __skip_nonitem_fields_set: bool
+    _skip_nonitem_fields = _NOT_SET
 
-    @property
-    def _skip_nonitem_fields(self) -> bool:
-        return getattr(
-            self.__class__, f"_{self.__class__.__name__}__skip_nonitem_fields", False
-        )
+    def _get_skip_nonitem_fields(self) -> bool:
+        value = self._skip_nonitem_fields
+        return False if value is _NOT_SET else value
 
-    def __init_subclass__(cls, skip_nonitem_fields: bool = False, **kwargs):
+    def __init_subclass__(cls, skip_nonitem_fields=_NOT_SET, **kwargs):
         super().__init_subclass__(**kwargs)
-
-        # See: https://github.com/scrapinghub/web-poet/issues/141
-        if not getattr(cls, f"_{cls.__name__}__skip_nonitem_fields_set", False):
-            setattr(cls, f"_{cls.__name__}__skip_nonitem_fields", skip_nonitem_fields)
-            setattr(cls, f"_{cls.__name__}__skip_nonitem_fields_set", True)
+        if skip_nonitem_fields is _NOT_SET:
+            # This is a workaround for attrs issue.
+            # See: https://github.com/scrapinghub/web-poet/issues/141
+            return
+        cls._skip_nonitem_fields = skip_nonitem_fields
 
     async def to_item(self) -> ItemT:
         """Extract an item from a web page"""
         return await item_from_fields(
-            self, item_cls=self.item_cls, skip_nonitem_fields=self._skip_nonitem_fields
+            self,
+            item_cls=self.item_cls,
+            skip_nonitem_fields=self._get_skip_nonitem_fields(),
         )
 
 


### PR DESCRIPTION
The idea of the fix: apparently, `__init_subclass__` is called multiple times (once per base class?), but in the incorrect invocations class arguments are not passed. So, we just skip those - do nothing if a default is not set.

I prefer it to the name mangling because there can be multiple classes with the same `cls.__name__`, which means we'd need to switch to something like get_fq_class_name, which makes the implementation more complex.

Checked it using the following code:

```py
from web_poet import Injectable
import attrs


NOT_SET = object()

class BasePage(Injectable):
    _skip_nonitem_fields = NOT_SET
    
    def __init_subclass__(cls, skip_nonitem_fields = NOT_SET, **kwargs):        
        super().__init_subclass__(**kwargs)
        print(cls, kwargs)
        
        if skip_nonitem_fields is not NOT_SET:            
            print(getattr(cls, "skip_nonitem_fields", "NOT_SET"))
            cls._skip_nonitem_fields = skip_nonitem_fields
            print(cls._skip_nonitem_fields)
        print("-"*48)
        print()
        
        
@attrs.define
class MyPage(BasePage, skip_nonitem_fields=True):
    pass


@attrs.define
class MyPage2(MyPage, skip_nonitem_fields=66):
    pass


@attrs.define
class MyPage3(BasePage):
    pass


@attrs.define
class MyPage4(MyPage2):
    pass


@attrs.define
class MyPage5(MyPage2, skip_nonitem_fields=55):
    pass
        
```