### PR TITLE
add .readthedocs.yml config

### DIFF
--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
         tox-job: ["mypy", "docs", "linters", "types"]
 
     steps:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ sphinx:
 build:
   os: ubuntu-22.10
   tools:
-    python: "3.7"  # Keep in sync with .github/workflows/tests-ubuntu.yml
+    python: "3.11"  # Keep in sync with .github/workflows/tests-ubuntu.yml
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,15 @@
+version: 2
+formats: all
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+build:
+  os: ubuntu-22.10
+  tools:
+    python: "3.7"  # Keep in sync with .github/workflows/tests-ubuntu.yml
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - path: .


### PR DESCRIPTION
Solves the issue of ReadTheDocs errors since it uses `async-lru==2.0.3` instead of `1.0.3` which is intended for Python 3.7 ([reference](https://readthedocs.org/projects/web-poet/builds/19661597/)).

The issue stems from not pinning the Python version in the `docs` toxenv which uses arbitrary Python version in ReadTheDocs.

This PR also adjusts GitHub actions as well.