### PR TITLE
turn off fail_on_warning

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,6 @@ version: 2
 formats: all
 sphinx:
   configuration: docs/conf.py
-  fail_on_warning: true
 
 build:
   os: ubuntu-22.04


### PR DESCRIPTION
From https://github.com/scrapinghub/web-poet/pull/148#issuecomment-1455611228

Default value is `False`. https://docs.readthedocs.io/en/stable/config-file/v2.html#sphinx-fail-on-warning