### PR TITLE
Improve and document processors for nested items

### DIFF
--- a/docs/page-objects/fields.rst
+++ b/docs/page-objects/fields.rst
@@ -272,7 +272,7 @@ Some item fields contain nested items (e.g. a product can contain a list of
 variants) and it's useful to have processors for fields of these nested items.
 You can use the same logic for them as for normal fields if you define an
 extractor class that produces these nested items. Such classes should inherit
-from :class:`~.Extractor`. In simplest cases you need to pass a selector to
+from :class:`~.Extractor`. In the simplest cases you need to pass a selector to
 them:
 
 .. code-block:: python

--- a/docs/page-objects/fields.rst
+++ b/docs/page-objects/fields.rst
@@ -316,6 +316,7 @@ dictionaries with some data:
 
 .. code-block:: python
 
+    @attrs.define
     class VariantExtractor(Extractor):
         variant_data: dict
 

--- a/docs/page-objects/fields.rst
+++ b/docs/page-objects/fields.rst
@@ -272,7 +272,8 @@ Some item fields contain nested items (e.g. a product can contain a list of
 variants) and it's useful to have processors for fields of these nested items.
 You can use the same logic for them as for normal fields if you define an
 extractor class that produces these nested items. Such classes should inherit
-from :class:`~.Extractor`:
+from :class:`~.Extractor`. In simplest cases you need to pass a selector to
+them:
 
 .. code-block:: python
 
@@ -299,6 +300,28 @@ from :class:`~.Extractor`:
         @field(out=[str.strip])
         def color(self):
             return self.sel.css(".name::text")
+
+In such cases you can also use :class:`~.SelectorExtractor` as a shortcut that
+provides ``css()`` and ``xpath()``:
+
+.. code-block:: python
+
+    class VariantExtractor(SelectorExtractor):
+        @field(out=[str.strip])
+        def color(self):
+            return self.css(".name::text")
+
+You can also pass other data in addition to, or instead of, selectors, such as
+dictionaries with some data:
+
+.. code-block:: python
+
+    class VariantExtractor(Extractor):
+        variant_data: dict
+
+        @field(out=[str.strip])
+        def color(self):
+            return self.variant_data["color"]
 
 
 .. _item-classes:

--- a/docs/page-objects/fields.rst
+++ b/docs/page-objects/fields.rst
@@ -270,15 +270,15 @@ Processors for nested fields
 
 Some item fields contain nested items (e.g. a product can contain a list of
 variants) and it's useful to have processors for fields of these nested items.
-You can use the same logic for them as for normal fields if you define a
-"partial page object" class that produces these nested items. Such classes
-should inherit from :class:`~.ItemPartial`:
+You can use the same logic for them as for normal fields if you define an
+extractor class that produces these nested items. Such classes should inherit
+from :class:`~.Extractor`:
 
 .. code-block:: python
 
     import attrs
     from parsel import Selector
-    from web_poet import ItemPage, HttpResponse, field
+    from web_poet import Extractor, ItemPage, HttpResponse, field
 
     @attrs.define
     class MyPage(ItemPage):
@@ -287,13 +287,13 @@ should inherit from :class:`~.ItemPartial`:
         @field
         async def variants(self):
             variants = []
-            for color in self.response.css(".color"):
-                variant = await VariantPartial(color).to_item()
+            for color_sel in self.response.css(".color"):
+                variant = await VariantExtractor(color_sel).to_item()
                 variants.append(variant)
             return variants
 
     @attrs.define
-    class VariantPartial(ItemPartial):
+    class VariantExtractor(Extractor):
         sel: Selector
 
         @field(out=[str.strip])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ pytest_plugins = ["pytester"]
 
 def read_fixture(path):
     path = os.path.join(os.path.dirname(__file__), path)
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         return f.read()
 
 

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -2,16 +2,15 @@ from typing import List, Optional
 
 import attrs
 import pytest
-from parsel import Selector
 
 from web_poet import HttpResponse, PageParams, field
 from web_poet.pages import (
-    Extractor,
     Injectable,
     ItemPage,
     ItemT,
     ItemWebPage,
     Returns,
+    SelectorExtractor,
     WebPage,
     is_injectable,
 )
@@ -251,13 +250,10 @@ async def test_extractor(book_list_html_response) -> None:
                 books.append(item)
             return books
 
-    @attrs.define
-    class BookExtractor(Extractor[Item]):
-        sel: Selector
-
+    class BookExtractor(SelectorExtractor[Item]):
         @field(out=[str.lower])
         def name(self):
-            return self.sel.css("img.thumbnail::attr(alt)").get()
+            return self.css("img.thumbnail::attr(alt)").get()
 
     page = MyPage(book_list_html_response)
     item = await page.to_item()

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -6,9 +6,9 @@ from parsel import Selector
 
 from web_poet import HttpResponse, PageParams, field
 from web_poet.pages import (
+    Extractor,
     Injectable,
     ItemPage,
-    ItemPartial,
     ItemT,
     ItemWebPage,
     Returns,
@@ -234,7 +234,7 @@ async def test_item_page_change_item_type_remove_fields() -> None:
 
 
 @pytest.mark.asyncio
-async def test_partial(book_list_html_response) -> None:
+async def test_extractor(book_list_html_response) -> None:
     @attrs.define
     class ListItem:
         books: List[Item]
@@ -247,12 +247,12 @@ async def test_partial(book_list_html_response) -> None:
         async def books(self):
             books = []
             for book in self.response.css("article"):
-                item = await BookPartial(book).to_item()
+                item = await BookExtractor(book).to_item()
                 books.append(item)
             return books
 
     @attrs.define
-    class BookPartial(ItemPartial[Item]):
+    class BookExtractor(Extractor[Item]):
         sel: Selector
 
         @field(out=[str.lower])

--- a/web_poet/__init__.py
+++ b/web_poet/__init__.py
@@ -18,6 +18,7 @@ from .pages import (
     ItemPage,
     ItemWebPage,
     Returns,
+    SelectorExtractor,
     WebPage,
     validates_input,
 )

--- a/web_poet/__init__.py
+++ b/web_poet/__init__.py
@@ -12,7 +12,15 @@ from .page_inputs import (
     RequestUrl,
     ResponseUrl,
 )
-from .pages import Injectable, ItemPage, ItemWebPage, Returns, WebPage, validates_input
+from .pages import (
+    Injectable,
+    ItemPage,
+    ItemPartial,
+    ItemWebPage,
+    Returns,
+    WebPage,
+    validates_input,
+)
 from .requests import request_downloader_var
 from .rules import (
     ApplyRule,

--- a/web_poet/__init__.py
+++ b/web_poet/__init__.py
@@ -13,9 +13,9 @@ from .page_inputs import (
     ResponseUrl,
 )
 from .pages import (
+    Extractor,
     Injectable,
     ItemPage,
-    ItemPartial,
     ItemWebPage,
     Returns,
     WebPage,

--- a/web_poet/fields.py
+++ b/web_poet/fields.py
@@ -142,17 +142,19 @@ def field(
             if inspect.iscoroutinefunction(method):
 
                 async def processed(page):
-                    validation_item = page._validate_input()
-                    if validation_item is not None:
-                        return getattr(validation_item, method.__name__)
+                    if hasattr(page, "_validate_input"):
+                        validation_item = page._validate_input()
+                        if validation_item is not None:
+                            return getattr(validation_item, method.__name__)
                     return _field._process(await method(page), page, processors)
 
             else:
 
                 def processed(page):
-                    validation_item = page._validate_input()
-                    if validation_item is not None:
-                        return getattr(validation_item, method.__name__)
+                    if hasattr(page, "_validate_input"):
+                        validation_item = page._validate_input()
+                        if validation_item is not None:
+                            return getattr(validation_item, method.__name__)
                     return _field._process(method(page), page, processors)
 
             return wraps(method)(processed)

--- a/web_poet/mixins.py
+++ b/web_poet/mixins.py
@@ -5,7 +5,7 @@ import parsel
 from w3lib.html import get_base_url
 
 
-class CssXpathMixin(abc.ABC):
+class CssXpathMixin:
     def xpath(self, query, **kwargs) -> parsel.SelectorList:
         """A shortcut to ``.selector.xpath()``."""
         return self.selector.xpath(query, **kwargs)  # type: ignore[attr-defined]
@@ -15,7 +15,7 @@ class CssXpathMixin(abc.ABC):
         return self.selector.css(query)  # type: ignore[attr-defined]
 
 
-class SelectableMixin(CssXpathMixin):
+class SelectableMixin(abc.ABC, CssXpathMixin):
     """
     Inherit from this mixin, implement ``._selector_input`` method,
     get ``.selector`` property and ``.xpath`` / ``.css`` methods.

--- a/web_poet/mixins.py
+++ b/web_poet/mixins.py
@@ -5,7 +5,17 @@ import parsel
 from w3lib.html import get_base_url
 
 
-class SelectableMixin(abc.ABC):
+class CssXpathMixin(abc.ABC):
+    def xpath(self, query, **kwargs) -> parsel.SelectorList:
+        """A shortcut to ``.selector.xpath()``."""
+        return self.selector.xpath(query, **kwargs)  # type: ignore[attr-defined]
+
+    def css(self, query) -> parsel.SelectorList:
+        """A shortcut to ``.selector.css()``."""
+        return self.selector.css(query)  # type: ignore[attr-defined]
+
+
+class SelectableMixin(CssXpathMixin):
     """
     Inherit from this mixin, implement ``._selector_input`` method,
     get ``.selector`` property and ``.xpath`` / ``.css`` methods.
@@ -28,14 +38,6 @@ class SelectableMixin(abc.ABC):
         sel = parsel.Selector(text=self._selector_input())
         self.__cached_selector = sel
         return sel
-
-    def xpath(self, query, **kwargs) -> parsel.SelectorList:
-        """A shortcut to ``.selector.xpath()``."""
-        return self.selector.xpath(query, **kwargs)
-
-    def css(self, query) -> parsel.SelectorList:
-        """A shortcut to ``.selector.css()``."""
-        return self.selector.css(query)
 
 
 # TODO: when dropping Python 3.7 support,

--- a/web_poet/mixins.py
+++ b/web_poet/mixins.py
@@ -5,7 +5,7 @@ import parsel
 from w3lib.html import get_base_url
 
 
-class CssXpathMixin:
+class SelectorShortcutsMixin:
     def xpath(self, query, **kwargs) -> parsel.SelectorList:
         """A shortcut to ``.selector.xpath()``."""
         return self.selector.xpath(query, **kwargs)  # type: ignore[attr-defined]
@@ -15,7 +15,7 @@ class CssXpathMixin:
         return self.selector.css(query)  # type: ignore[attr-defined]
 
 
-class SelectableMixin(abc.ABC, CssXpathMixin):
+class SelectableMixin(abc.ABC, SelectorShortcutsMixin):
     """
     Inherit from this mixin, implement ``._selector_input`` method,
     get ``.selector`` property and ``.xpath`` / ``.css`` methods.

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -83,8 +83,7 @@ def validates_input(to_item: CallableT) -> CallableT:
 
 
 class Extractor(Returns[ItemT], FieldsMixin):
-    """The base class for page objects and other extractors, providing support
-    for fields."""
+    """Base class for field support."""
 
     _skip_nonitem_fields = _NOT_SET
 
@@ -110,9 +109,7 @@ class Extractor(Returns[ItemT], FieldsMixin):
 
 
 class ItemPage(Extractor[ItemT], Injectable):
-    """Base Page Object, with a default :meth:`to_item` implementation
-    which supports web-poet fields.
-    """
+    """Base class for page objects."""
 
     @cached_method
     def _validate_input(self) -> None:
@@ -151,8 +148,7 @@ ItemWebPage = _create_deprecated_class("ItemWebPage", WebPage, warn_once=False)
 
 @attr.s(auto_attribs=True)
 class SelectorExtractor(Extractor[ItemT], CssXpathMixin):
-    """Extractor that takes a :class:`parsel.Selector` and provides
-    XPath / CSS shortcuts.
-    """
+    """Extractor that takes a :class:`parsel.Selector` and provides shortcuts 
+    for its methods."""
 
     selector: parsel.Selector

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -100,9 +100,6 @@ class Extractor(Returns[ItemT], FieldsMixin):
             return
         cls._skip_nonitem_fields = skip_nonitem_fields
 
-    def _validate_input(self) -> None:
-        return None
-
     async def to_item(self) -> ItemT:
         """Extract an item"""
         return await item_from_fields(

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -9,7 +9,7 @@ import parsel
 
 from web_poet._typing import get_item_cls
 from web_poet.fields import FieldsMixin, item_from_fields
-from web_poet.mixins import ResponseShortcutsMixin
+from web_poet.mixins import CssXpathMixin, ResponseShortcutsMixin
 from web_poet.page_inputs import HttpResponse
 from web_poet.utils import CallableT, _create_deprecated_class, cached_method
 
@@ -150,17 +150,9 @@ ItemWebPage = _create_deprecated_class("ItemWebPage", WebPage, warn_once=False)
 
 
 @attr.s(auto_attribs=True)
-class SelectorExtractor(Extractor[ItemT]):
+class SelectorExtractor(Extractor[ItemT], CssXpathMixin):
     """Extractor that takes a :class:`parsel.Selector` and provides
     XPath / CSS shortcuts.
     """
 
     selector: parsel.Selector
-
-    def xpath(self, query, **kwargs) -> parsel.SelectorList:
-        """A shortcut to ``.selector.xpath()``."""
-        return self.selector.xpath(query, **kwargs)
-
-    def css(self, query) -> parsel.SelectorList:
-        """A shortcut to ``.selector.css()``."""
-        return self.selector.css(query)

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -5,6 +5,7 @@ from contextlib import suppress
 from functools import wraps
 
 import attr
+import parsel
 
 from web_poet._typing import get_item_cls
 from web_poet.fields import FieldsMixin, item_from_fields
@@ -149,3 +150,20 @@ class WebPage(ItemPage[ItemT], ResponseShortcutsMixin):
 
 
 ItemWebPage = _create_deprecated_class("ItemWebPage", WebPage, warn_once=False)
+
+
+@attr.s(auto_attribs=True)
+class SelectorExtractor(Extractor[ItemT]):
+    """Extractor that takes a :class:`parsel.Selector` and provides
+    XPath / CSS shortcuts.
+    """
+
+    selector: parsel.Selector
+
+    def xpath(self, query, **kwargs) -> parsel.SelectorList:
+        """A shortcut to ``.selector.xpath()``."""
+        return self.selector.xpath(query, **kwargs)
+
+    def css(self, query) -> parsel.SelectorList:
+        """A shortcut to ``.selector.css()``."""
+        return self.selector.css(query)

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -81,10 +81,9 @@ def validates_input(to_item: CallableT) -> CallableT:
     return _to_item  # type: ignore[return-value]
 
 
-class ItemPage(Injectable, Returns[ItemT]):
-    """Base Page Object, with a default :meth:`to_item` implementation
-    which supports web-poet fields.
-    """
+class ItemBase(Returns[ItemT]):
+    """The base class for ItemPage and ItemPartial, providing support
+    for fields."""
 
     _skip_nonitem_fields = _NOT_SET
 
@@ -125,6 +124,18 @@ class ItemPage(Injectable, Returns[ItemT]):
         validation_item = self.validate_input()  # type: ignore[attr-defined]
         self.__validating_input = False
         return validation_item
+
+
+class ItemPage(ItemBase[ItemT], Injectable):
+    """Base Page Object, with a default :meth:`to_item` implementation
+    which supports web-poet fields.
+    """
+
+
+class ItemPartial(ItemBase[ItemT], FieldsMixin):
+    """Base class for partial objects."""
+
+    pass
 
 
 @attr.s(auto_attribs=True)

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -9,7 +9,7 @@ import parsel
 
 from web_poet._typing import get_item_cls
 from web_poet.fields import FieldsMixin, item_from_fields
-from web_poet.mixins import CssXpathMixin, ResponseShortcutsMixin
+from web_poet.mixins import ResponseShortcutsMixin, SelectorShortcutsMixin
 from web_poet.page_inputs import HttpResponse
 from web_poet.utils import CallableT, _create_deprecated_class, cached_method
 
@@ -147,8 +147,8 @@ ItemWebPage = _create_deprecated_class("ItemWebPage", WebPage, warn_once=False)
 
 
 @attr.s(auto_attribs=True)
-class SelectorExtractor(Extractor[ItemT], CssXpathMixin):
-    """Extractor that takes a :class:`parsel.Selector` and provides shortcuts 
+class SelectorExtractor(Extractor[ItemT], SelectorShortcutsMixin):
+    """Extractor that takes a :class:`parsel.Selector` and provides shortcuts
     for its methods."""
 
     selector: parsel.Selector


### PR DESCRIPTION
This extracts `ItemBase` from `ItemPage`, the only difference between them being `ItemPage` inheriting from `Injectable`. It also adds `ItemPartial` which too inherits from `ItemBase` but adds `FieldsMixin` instead of `Injectable`. Actually, as `Injectable` inherits from `FieldsMixin` we coud have just `ItemBase` (inheriting from `FieldsMixin`) and `ItemPage` and use `ItemBase` directly in the user code.

Both new classes can be renamed.