### PR TITLE
Store HttpError exceptions in HttpClient serialization

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -182,7 +182,7 @@ async def test_http_client_batch_execute(async_mock) -> None:
     ]
     responses = await client.batch_execute(*requests)
 
-    assert all([isinstance(response, HttpResponse) for response in responses])
+    assert all(isinstance(response, HttpResponse) for response in responses)
 
 
 @pytest.fixture
@@ -275,7 +275,7 @@ async def test_http_client_batch_execute_allow_status(
             and isinstance(r.request, HttpRequest)
             and isinstance(r.response, HttpResponse)
         )
-    assert all([str(r).startswith("400 BAD_REQUEST response for") for r in responses])
+    assert all(str(r).startswith("400 BAD_REQUEST response for") for r in responses)
 
     responses = await client.batch_execute(
         *requests, return_exceptions=True, allow_status=408
@@ -286,7 +286,7 @@ async def test_http_client_batch_execute_allow_status(
             and isinstance(r.request, HttpRequest)
             and isinstance(r.response, HttpResponse)
         )
-    assert all([str(r).startswith("400 BAD_REQUEST response for") for r in responses])
+    assert all(str(r).startswith("400 BAD_REQUEST response for") for r in responses)
 
     # These have no assertions since they're used to see if mypy raises an
     # error against them.

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -180,7 +180,7 @@ def test_list_page_objects_all() -> None:
     #   - web_poet.consume_modules("tests_extra")
     # Merely having `import tests_extra` won't work since the subpackages and
     # modules needs to be traversed and imported as well.
-    assert all(["po_lib_sub_not_imported" not in po.__module__ for po in page_objects])
+    assert all("po_lib_sub_not_imported" not in po.__module__ for po in page_objects)
 
     # Ensure that ALL Override Rules are returned as long as the given
     # registry's @handle_urls decorator was used.
@@ -225,7 +225,7 @@ def test_registry_get_overrides_deprecation() -> None:
 
     # but the rules from ``.get_overrides()`` should return ``ApplyRule`` and
     # not the old ``OverrideRule``.
-    assert all([r for r in rules if isinstance(r, ApplyRule)])
+    assert all(r for r in rules if isinstance(r, ApplyRule))
 
 
 def test_consume_module_not_existing() -> None:
@@ -240,7 +240,7 @@ def test_list_page_objects_all_consume() -> None:
     consume_modules("tests_extra")
     rules = default_registry.get_rules()
     page_objects = {po.use for po in rules}
-    assert any(["po_lib_sub_not_imported" in po.__module__ for po in page_objects])
+    assert any("po_lib_sub_not_imported" in po.__module__ for po in page_objects)
 
 
 def test_registry_search() -> None:

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -12,7 +12,7 @@ from itemadapter import ItemAdapter
 from zyte_common_items import Item, Metadata, Product
 
 from web_poet import HttpClient, HttpRequest, HttpResponse, WebPage, field
-from web_poet.exceptions import HttpResponseError
+from web_poet.exceptions import HttpRequestError, HttpResponseError
 from web_poet.page_inputs.client import _SavedResponseData
 from web_poet.testing import Fixture
 from web_poet.testing.__main__ import main as cli_main
@@ -336,7 +336,7 @@ def test_httpclient_no_response(pytester, book_list_html_response) -> None:
 
 
 @attrs.define
-class ClientExceptionPage(WebPage):
+class ClientResponseErrorPage(WebPage):
     client: HttpClient
 
     async def to_item(self) -> dict:
@@ -348,7 +348,7 @@ class ClientExceptionPage(WebPage):
         return {"foo": "bar", "exception": msg}
 
 
-def test_httpclient_exception(pytester, book_list_html_response) -> None:
+def test_httpclient_response_exception(pytester, book_list_html_response) -> None:
     url = "http://books.toscrape.com/1.html"
     request = HttpRequest(url)
     response = HttpResponse(url=url, body=b"body1", status=404, encoding="utf-8")
@@ -363,10 +363,51 @@ def test_httpclient_exception(pytester, book_list_html_response) -> None:
     }
     _save_fixture(
         pytester,
-        page_cls=ClientExceptionPage,
+        page_cls=ClientResponseErrorPage,
         page_inputs=[book_list_html_response, client],
         expected=item,
     )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=4)
+
+
+@attrs.define
+class ClientRequestErrorPage(WebPage):
+    client: HttpClient
+
+    async def to_item(self) -> dict:
+        msg = ""
+        try:
+            await self.client.get("http://books.toscrape.com/1.html")
+        except HttpRequestError as ex:
+            msg = ex.args[0]
+        return {"foo": "bar", "exception": msg}
+
+
+def test_httpclient_request_exception(pytester, book_list_html_response) -> None:
+    url = "http://books.toscrape.com/1.html"
+    request = HttpRequest(url)
+    exception = HttpRequestError("Bad Request", request)
+    responses = [
+        _SavedResponseData(request, None, exception),
+    ]
+    client = HttpClient(responses=responses)
+
+    item = {
+        "foo": "bar",
+        "exception": "Bad Request",
+    }
+    fixture = _save_fixture(
+        pytester,
+        page_cls=ClientRequestErrorPage,
+        page_inputs=[book_list_html_response, client],
+        expected=item,
+    )
+    assert (fixture.input_path / "HttpClient-0-exception_type.txt").exists()
+    assert (fixture.input_path / "HttpClient-0-exception.msg.txt").exists()
+    assert (
+        fixture.input_path / "HttpClient-0-exception.HttpRequest.info.json"
+    ).exists()
     result = pytester.runpytest()
     result.assert_outcomes(passed=4)
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -403,11 +403,7 @@ def test_httpclient_request_exception(pytester, book_list_html_response) -> None
         page_inputs=[book_list_html_response, client],
         expected=item,
     )
-    assert (fixture.input_path / "HttpClient-0-exception_type.txt").exists()
-    assert (fixture.input_path / "HttpClient-0-exception.msg.txt").exists()
-    assert (
-        fixture.input_path / "HttpClient-0-exception.HttpRequest.info.json"
-    ).exists()
+    assert (fixture.input_path / "HttpClient-0-exception.json").exists()
     result = pytester.runpytest()
     result.assert_outcomes(passed=4)
 

--- a/web_poet/page_inputs/client.py
+++ b/web_poet/page_inputs/client.py
@@ -198,6 +198,8 @@ class HttpClient:
                 if request_fingerprint(request) == fp:
                     if saved_data.exception:
                         raise saved_data.exception
+                    if not saved_data.response:
+                        continue
                     self._handle_status(
                         saved_data.response,
                         saved_data.request,

--- a/web_poet/page_inputs/client.py
+++ b/web_poet/page_inputs/client.py
@@ -79,7 +79,7 @@ class HttpClient:
     ) -> None:
         allow_status_normalized = list(map(str, as_list(allow_status)))
         allow_all_status = any(
-            [True for s in allow_status_normalized if "*" == s.strip()]
+            True for s in allow_status_normalized if "*" == s.strip()
         )
 
         if (

--- a/web_poet/page_inputs/client.py
+++ b/web_poet/page_inputs/client.py
@@ -198,8 +198,7 @@ class HttpClient:
                 if request_fingerprint(request) == fp:
                     if saved_data.exception:
                         raise saved_data.exception
-                    if not saved_data.response:
-                        continue
+                    assert saved_data.response
                     self._handle_status(
                         saved_data.response,
                         saved_data.request,

--- a/web_poet/serialization/functions.py
+++ b/web_poet/serialization/functions.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List, Type
+from typing import Dict, List, Optional, Type
 
 from .. import (
     HttpClient,
@@ -167,6 +167,7 @@ def _deserialize_HttpClient(
             response = deserialize_leaf(HttpResponse, serialized_response)
         else:
             response = None
+        exception: Optional[HttpError]
         if serialized_exception:
             exc_type = load_class(serialized_exception_types[key])
             exception = deserialize_leaf(exc_type, serialized_exception)


### PR DESCRIPTION
This allows us to test requests that fail with HttpError, not just return a non-200 status.