### PR TITLE
jmespath shortcut

### DIFF
--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - python-version: '3.11'
             env:
-              TOXENV: oldpytest
+              TOXENV: old
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - python-version: '3.11'
             env:
-              TOXENV: oldpytest
+              TOXENV: old
 
     steps:
     - uses: actions/checkout@v3

--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -67,6 +67,7 @@ Mixins
 
 .. autoclass:: web_poet.mixins.ResponseShortcutsMixin
    :members:
+   :inherited-members:
    :no-special-members:
 
 Requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,25 @@ def book_list_html():
     return read_fixture("fixtures/book_list.html")
 
 
+@pytest.fixture()
+def some_json_response():
+    body = """
+    {
+      "description": "paragraph",
+      "website": {
+        "url": "http://www.scrapy.org",
+        "name": "homepage"
+      },
+      "logo": "/images/logo.png"
+    }
+    """
+    return HttpResponse(
+        url="http://books.toscrape.com/result.json",
+        body=body.encode("utf-8"),
+        encoding="utf-8",
+    )
+
+
 @pytest.fixture
 def book_list_html_response(book_list_html):
     body = HttpResponseBody(bytes(book_list_html, "utf-8"))

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,7 +1,12 @@
+import packaging.version as version
+import parsel
 import pytest
 
 from web_poet.mixins import ResponseShortcutsMixin
 from web_poet.page_inputs import HttpResponse
+
+PARSEL_VERSION = version.parse(getattr(parsel, "__version__", "0.0"))
+PARSEL_18_PLUS = PARSEL_VERSION >= version.parse("1.8.0")
 
 
 class MyPage(ResponseShortcutsMixin):
@@ -11,8 +16,12 @@ class MyPage(ResponseShortcutsMixin):
 
 @pytest.fixture
 def my_page(book_list_html_response):
-
     return MyPage(book_list_html_response)
+
+
+@pytest.fixture
+def my_json_page(some_json_response):
+    return MyPage(some_json_response)
 
 
 def test_url(my_page) -> None:
@@ -26,6 +35,20 @@ def test_html(my_page, book_list_html) -> None:
 def test_xpath(my_page) -> None:
     title = my_page.xpath(".//title/text()").get().strip()
     assert title == "All products | Books to Scrape - Sandbox"
+
+
+@pytest.mark.skipif(not PARSEL_18_PLUS, reason="parsel < 1.8 doesn't support jmespath")
+def test_jmespath(my_json_page) -> None:
+    for obj in [my_json_page, my_json_page.response]:
+        name = obj.jmespath("website.name").get()
+        assert name == "homepage"
+
+
+@pytest.mark.skipif(PARSEL_18_PLUS, reason="parsel >= 1.8 supports jmespath")
+def test_jmespath_not_available(my_json_page) -> None:
+    for obj in [my_json_page, my_json_page.response]:
+        with pytest.raises(AttributeError):
+            obj.jmespath("website.name").get()
 
 
 def test_css(my_page) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -59,10 +59,11 @@ commands =
 deps = -rrequirements-dev.txt
 commands = pre-commit run --all-files --show-diff-on-failure
 
-[testenv:oldpytest]
+[testenv:old]
 deps =
     {[testenv]deps}
     pytest < 7.0
+    parsel < 1.8
 
 [testenv:twinecheck]
 basepython = python3

--- a/web_poet/mixins.py
+++ b/web_poet/mixins.py
@@ -26,7 +26,8 @@ class SelectorShortcutsMixin:
 class SelectableMixin(abc.ABC, SelectorShortcutsMixin):
     """
     Inherit from this mixin, implement ``._selector_input`` method,
-    get ``.selector`` property and ``.xpath`` / ``.css`` methods.
+    get ``.selector`` property and ``.xpath`` / ``.css`` / "``.jmespath``
+    methods.
     """
 
     __cached_selector = None

--- a/web_poet/mixins.py
+++ b/web_poet/mixins.py
@@ -14,6 +14,14 @@ class SelectorShortcutsMixin:
         """A shortcut to ``.selector.css()``."""
         return self.selector.css(query)  # type: ignore[attr-defined]
 
+    def jmespath(self, query: str, **kwargs) -> parsel.SelectorList:
+        """A shortcut to ``.selector.jmespath()``."""
+        if not hasattr(self.selector, "jmespath"):  # type: ignore[attr-defined]
+            raise AttributeError(
+                "Please install parsel >= 1.8.1 to get jmespath support"
+            )
+        return self.selector.jmespath(query, **kwargs)  # type: ignore[attr-defined]
+
 
 class SelectableMixin(abc.ABC, SelectorShortcutsMixin):
     """


### PR DESCRIPTION
I opted in for a runtime check to simplify the implementation a bit. We can drop it after bumping min parsel version requirement.