### PR TITLE
Refactor the rules documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ web-poet
 .. intro starts
 
 ``web-poet`` is a Python 3.7+ implementation of the `page object pattern`_ for
-web scraping. It enables writing portable, reusable web data extraction code.
+web scraping. It enables writing portable, reusable web parsing code.
 
 .. _page object pattern: https://martinfowler.com/bliki/PageObject.html
 

--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -91,8 +91,7 @@ Exceptions
 Apply Rules
 ===========
 
-See the tutorial section on :ref:`rules-intro` for more context about its
-use cases and some examples.
+See :ref:`rules` for more context about its use cases and some examples.
 
 .. autofunction:: web_poet.handle_urls
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -201,7 +201,7 @@ intersphinx_mapping = {
         None,
     ),
     "url-matcher": (
-        "https://url-matcher.readthedocs.io/en/stable/",
+        "https://url-matcher.readthedocs.io/en/latest/",
         None,
     ),
     "parsel": (

--- a/docs/frameworks/index.rst
+++ b/docs/frameworks/index.rst
@@ -48,7 +48,7 @@ framework further to:
     module as possible.
 
 -   Support returning a :ref:`page object <page-objects>` given a target URL
-    and a desired :ref:`output item type <items>`, determining the right
+    and a desired :ref:`output item class <items>`, determining the right
     :ref:`page object class <page-object-classes>` to use based on :ref:`rules
     <framework-rules>`.
 
@@ -63,4 +63,5 @@ framework further to:
 
 -   Support :ref:`retries <framework-retries>`.
 
--   Let users set their own :class:`~web_poet.rules.RulesRegistry` object.
+-   Let users set their own :ref:`rules <rules>`, e.g. to :ref:`solve conflicts
+    <rule-conflicts>`.

--- a/docs/frameworks/index.rst
+++ b/docs/frameworks/index.rst
@@ -48,9 +48,9 @@ framework further to:
     module as possible.
 
 -   Support returning a :ref:`page object <page-objects>` given a target URL
-    and a desired :ref:`output item type <items>`, using
-    ``web_poet.default_registry`` to determine the right :ref:`page
-    object class <page-object-classes>` to use.
+    and a desired :ref:`output item type <items>`, determining the right
+    :ref:`page object class <page-object-classes>` to use based on :ref:`rules
+    <framework-rules>`.
 
 -   Allow users to request an :ref:`output item <items>` directly, instead of
     requesting a page object just to call its ``to_item`` method.

--- a/docs/frameworks/rules.rst
+++ b/docs/frameworks/rules.rst
@@ -18,9 +18,6 @@ a page object based on rules:
 
     page_cls = default_registry.page_cls_for_item("https://example.com", MyItem)
 
-To give your users more flexibility, you can also let them configure an
-alternative :class:`~.RulesRegistry` object to be used for rule resolution.
-
 You should also let your users know what is the best approach to :ref:`load
 rules <load-rules>` when using your framework. For example, let them know the
 best location for their calls to the :func:`~.web_poet.rules.consume_modules`

--- a/docs/frameworks/rules.rst
+++ b/docs/frameworks/rules.rst
@@ -1,0 +1,27 @@
+.. _framework-rules:
+
+================
+Supporting rules
+================
+
+Ideally, a framework should support returning the right :ref:`page object
+<page-objects>` or :ref:`output item <items>` given a target URL and a desired
+:ref:`output item type <items>` when :ref:`rules <rules>` are used.
+
+To provide basic support for rules in your framework, use the
+:class:`~.RulesRegistry` object at ``web_poet.default_registry`` to choose
+a page object based on rules:
+
+.. code-block:: python
+
+    from web_poet import default_registry
+
+    page_cls = default_registry.page_cls_for_item("https://example.com", MyItem)
+
+To give your users more flexibility, you can also let them configure an
+alternative :class:`~.RulesRegistry` object to be used for rule resolution.
+
+You should also let your users know what is the best approach to :ref:`load
+rules <load-rules>` when using your framework. For example, let them know the
+best location for their calls to the :func:`~.web_poet.rules.consume_modules`
+function.

--- a/docs/frameworks/rules.rst
+++ b/docs/frameworks/rules.rst
@@ -6,7 +6,7 @@ Supporting rules
 
 Ideally, a framework should support returning the right :ref:`page object
 <page-objects>` or :ref:`output item <items>` given a target URL and a desired
-:ref:`output item type <items>` when :ref:`rules <rules>` are used.
+:ref:`output item class <items>` when :ref:`rules <rules>` are used.
 
 To provide basic support for rules in your framework, use the
 :class:`~.RulesRegistry` object at ``web_poet.default_registry`` to choose

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ web-poet
    :maxdepth: 1
 
    frameworks/index
+   Rules <frameworks/rules>
    Additional requests <frameworks/additional-requests>
    Retries <frameworks/retries>
 

--- a/docs/intro/from-ground-up.rst
+++ b/docs/intro/from-ground-up.rst
@@ -181,7 +181,21 @@ can then refactor your ``BookPage`` class as follows:
     class BookPage(WebPage):
         def to_item(self) -> dict:
             return {
-                "url": self..url,
+                "url": self.response.url,
+                "title": self.response.css("h1").get(),
+            }
+
+:class:`~.WebPage` even provides shortcuts for some response attributes and
+methods:
+
+.. code-block:: python
+
+    from web_poet import WebPage
+
+    class BookPage(WebPage):
+        def to_item(self) -> dict:
+            return {
+                "url": self.url,
                 "title": self.css("h1").get(),
             }
 

--- a/docs/intro/from-ground-up.rst
+++ b/docs/intro/from-ground-up.rst
@@ -181,8 +181,8 @@ can then refactor your ``BookPage`` class as follows:
     class BookPage(WebPage):
         def to_item(self) -> dict:
             return {
-                "url": self.response.url,
-                "title": self.response.css("h1").get(),
+                "url": self..url,
+                "title": self.css("h1").get(),
             }
 
 At this point you may be wondering why web-poet requires you to write a class
@@ -224,11 +224,13 @@ What about the implementation of the ``download`` function? How would you
 implement that in web-poet? Well, ideally, you wouldn’t.
 
 To parse data from a web page using web-poet, you would only need to write the
-parsing part, e.g. the ``BookPage`` page object class above.
+parsing part, e.g. the ``BookPage`` :ref:`page object class
+<page-object-classes>` above.
 
 Then, you let a :ref:`web-poet framework <frameworks>` handle the download part
-for you. You pass that framework the ``BookPage`` class and the URL of a web
-page to parse, and that's it:
+for you. You pass that framework the URL of a web page to parse, and either a
+page object class (the ``BookPage`` class here) or an :ref:`item class
+<items>`, and that's it:
 
 .. code-block:: python
 
@@ -236,8 +238,8 @@ page to parse, and that's it:
 
 web-poet does *not* provide any framework, beyond :ref:`an example one featured
 in the tutorial <tutorial-create-page-object>` and not intended for production.
-The role of web-poet is to define a standard on how to write parsing logic so
-that it can be reused with different frameworks.
+The role of web-poet is to define a specification on how to write parsing logic
+so that it can be reused with different frameworks.
 
 :ref:`Page object classes <page-object-classes>` should be flexible enough to
 be used with very different frameworks, including:

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -4,8 +4,8 @@
 Tutorial
 ========
 
-In this tutorial you will learn to use web-poet as you write web data
-extraction code for book detail pages from `books.toscrape.com`_.
+In this tutorial you will learn to use web-poet as you write web scraping code
+for book detail pages from `books.toscrape.com`_.
 
 .. _books.toscrape.com: http://books.toscrape.com/
 
@@ -18,8 +18,8 @@ To follow this tutorial you must first be familiar with Python_ and have
 Create a project directory
 ==========================
 
-web-poet does not limit how you structure your web-poet web data extraction
-code, beyond the limitations of Python itself.
+web-poet does not limit how you structure your web-poet web scraping code,
+beyond the limitations of Python itself.
 
 However, in this tutorial you will use a specific project directory structure
 designed with web-poet best practices in mind. Consider using a similar project
@@ -30,9 +30,9 @@ First create your project directory: ``tutorial-project/``.
 Within the ``tutorial-project`` directory, create:
 
 -   A ``run.py`` file, a file specific to this tutorial where you will put code
-    to test the execution of your web data extraction code.
+    to test the execution of your web scraping code.
 
--   A ``tutorial`` directory, where you will place your web data extraction code.
+-   A ``tutorial`` directory, where you will place your web scraping code.
 
 Within the ``tutorial-project/tutorial`` directory, create:
 
@@ -110,9 +110,9 @@ many different websites that provide data with a similar data schema.
 Create a page object class
 ==========================
 
-To write web data extraction code with web-poet, you write :ref:`page object
-classes <page-objects>`, Python classes that define how to extract data from a
-given type of input, usually some type of webpage from a specific website.
+To write web parsing code with web-poet, you write :ref:`page object classes
+<page-objects>`, Python classes that define how to extract data from a given
+type of input, usually some type of webpage from a specific website.
 
 In this tutorial you will write a page object class for webpages of
 `books.toscrape.com`_ that show details about a book, such as these:
@@ -147,7 +147,7 @@ In the code above:
         :meth:`~web_poet.pages.WebPage.css`,
         :meth:`~web_poet.pages.WebPage.urljoin`, and
         :meth:`~web_poet.pages.WebPage.xpath`, that make it easier to write
-        web data extraction code.
+        parsing code.
 
 -   ``BookPage`` declares ``Book`` as its return type.
 
@@ -178,7 +178,7 @@ In the code above:
     on the input HTTP response.
 
     Here, ``title`` is not an arbitrary name. It was chosen specifically to
-    match ``Book.title``, so that during web data extraction the value that
+    match ``Book.title``, so that during parsing the value that
     ``BookPage.title`` returns gets mapped to ``Book.title``.
 
 
@@ -212,14 +212,17 @@ And the ``print(item)`` statement should output the following:
    Book(title='The Exiled')
 
 In this tutorial you use ``web_poet.example.get_item``, which is a simple,
-incomplete implementation of the web-poet standard, built specifically for this
-tutorial, for demonstration purposes. In real projects, use instead an actual
-web-poet framework, like `scrapy-poet`_.
+incomplete implementation of the web-poet specification, built specifically for
+this tutorial, for demonstration purposes. In real projects, use instead an
+actual :ref:`web-poet framework <frameworks>`.
 
 ``web_poet.example.get_item`` serves to illustrate the power of web-poet: once
 you have defined your page object class, a web-poet framework only needs 2
-inputs from you: the URL from which you want to extract data, and the desired
-output item class.
+inputs from you:
+
+-   the URL from which you want to extract data, and
+-   the desired output, either a :ref:`page object class <page-object-classes>`
+    or, in this case, an :ref:`item class <items>`.
 
 Notice that you must also call :func:`~web_poet.rules.consume_modules` once
 before your first call to ``get_item``. ``consume_modules`` ensures that the
@@ -253,8 +256,6 @@ Your web-poet framework can take care of everything else:
     from :class:`~web_poet.pages.ItemPage`, which in turn uses all fields of
     ``BookPage`` to create an instance of ``Book``, which you declared as the
     return type of ``BookPage``.
-
-.. _scrapy-poet: https://scrapy-poet.readthedocs.io
 
 
 Extend and override your code
@@ -401,17 +402,17 @@ You may notice that the execution takes longer now. That is because
 ``CategorizedBookPage`` now requires 2 or more requests, to find the value of
 the ``category_rank`` attribute.
 
-If you use ``CategorizedBookPage`` as part of a web data extraction project
-that targets a single book URL, it cannot be helped. If you want to extract the
+If you use ``CategorizedBookPage`` as part of a web scraping project that
+targets a single book URL, it cannot be helped. If you want to extract the
 ``category_rank`` attribute, you need those additional requests. Your only
 option to avoid additional requests is to stop extracting the ``category_rank``
 attribute.
 
-However, if your web data extraction project is targeting all book URLs from
-one or more categories by visiting those category URLs, extracting book URLs
-from them, and then using ``CategorizedBookPage`` with those book URLs as
-input, there is something you can change to save many requests: keep track of
-the positions where you find books as you visit their categories, and pass that
+However, if your web scraping project is targeting all book URLs from one or
+more categories by visiting those category URLs, extracting book URLs from
+them, and then using ``CategorizedBookPage`` with those book URLs as input,
+there is something you can change to save many requests: keep track of the
+positions where you find books as you visit their categories, and pass that
 position to ``CategorizedBookPage`` as additional input.
 
 Extend ``CategorizedBookPage`` in

--- a/docs/page-objects/index.rst
+++ b/docs/page-objects/index.rst
@@ -64,7 +64,7 @@ Getting the output item
 =======================
 
 You should :ref:`include your page object classes into a page object
-registry <rules-intro>`, e.g. decorate them with :func:`~.handle_urls`:
+registry <rules>`, e.g. decorate them with :func:`~.handle_urls`:
 
 .. literalinclude:: code-examples/register.py
 

--- a/docs/page-objects/index.rst
+++ b/docs/page-objects/index.rst
@@ -70,9 +70,9 @@ registry <rules>`, e.g. decorate them with :func:`~.handle_urls`:
 
 Then, provided your page object class code is imported (see
 :func:`~web_poet.rules.consume_modules`), your :ref:`framework <frameworks>`
-can build the output item after you provide the required input, such as the
-target URL and the desired :ref:`output item class <items>`, as :ref:`shown in
-the tutorial <tutorial-create-page-object>`.
+can build the output item after you provide the target URL and the desired
+:ref:`output item class <items>`, as :ref:`shown in the tutorial
+<tutorial-create-page-object>`.
 
 Your framework chooses the right page object class based on your input
 parameters, downloads the required data, builds a page object, and calls the

--- a/docs/page-objects/items.rst
+++ b/docs/page-objects/items.rst
@@ -21,27 +21,27 @@ class. For example:
 .. _attrs: https://www.attrs.org/en/stable/
 .. _itemadapter: https://github.com/scrapy/itemadapter
 
-Because itemadapter_ allows implementing support for arbitrary types,
+Because itemadapter_ allows implementing support for arbitrary classes,
 any kind of Python object can potentially work as an item.
 
-Best practices for item types
-=============================
+Best practices for item classes
+===============================
 
 To keep your code maintainable, we recommend you to:
 
--   Reuse item types.
+-   Reuse item classes.
 
     For example, if you want to extract product details data from 2 e-commerce
-    websites, try to use the same item type for both of them. Or at least try
-    to define a base item type with shared fields, and only keep
+    websites, try to use the same item class for both of them. Or at least try
+    to define a base item class with shared fields, and only keep
     website-specific fields in website-specific items.
 
--   Keep item types as logic-free as possible.
+-   Keep item classes as logic-free as possible.
 
     For example, any parsing and field cleanup logic is better handled through
     :ref:`page object classes <page-object-classes>`, e.g. using :ref:`field
     processors <field-processors>`.
 
-If you are looking for ready-made item types, check out `zyte-common-items`_.
+If you are looking for ready-made item classes, check out `zyte-common-items`_.
 
 .. _zyte-common-items: https://zyte-common-items.readthedocs.io/en/latest/index.html

--- a/docs/page-objects/rules.rst
+++ b/docs/page-objects/rules.rst
@@ -5,8 +5,17 @@ Rules
 =====
 
 Rules are :class:`~.ApplyRule` objects that tell web-poet which :ref:`page
-object class <page-object-classes>` to use for a given combination of input URL
-and :ref:`item type <item-types>`.
+object class <page-object-classes>` to use based on user input, i.e. the target
+URL and an output class (a :ref:`page object class <page-object-classes>` or an
+:ref:`item class <items>`).
+
+Rules are necessary to enable using an item class as output class, and can also
+be useful as documentation or to get information about page object classes
+programmatically.
+
+:ref:`Rule precedence <rule-precedence>` can also be useful. For example, to
+implement generic page object classes that you can override for specific
+websites.
 
 Defining rules
 ==============
@@ -28,7 +37,7 @@ a page object. For example:
 
 The code above tells web-poet to use the ``MyPage`` :ref:`page object class
 <page-object-classes>` when given a URL pointing to the ``example.com`` domain
-name and being asked for an :ref:`item <items>` of type ``MyItem``.
+name and being asked for ``MyPage`` or ``MyItem`` as output class.
 
 Alternatively, you can manually create and register :class:`~.ApplyRule`
 objects:
@@ -57,14 +66,25 @@ Every rule defines a :class:`url_matcher.Patterns` object that determines if
 any given URL is a match for the rule.
 
 :class:`~url_matcher.Patterns` objects offer a simple but powerful syntax for
-URL matching. For details and examples, see the :ref:`url-matcher documentation
+URL matching. For example:
+
+======================= ===============================================================
+Pattern                 Behavior
+======================= ===============================================================
+(empty string)          Matches any URL
+example.com             Matches any URL on the example.com domain and subdomains
+example.com/products/   Matches example.com URLs under the /products/ path
+example.com?productId=* Matches example.com URLs with productId=… in their query string
+======================= ===============================================================
+
+For details and more examples, see the :ref:`url-matcher documentation
 <url-matcher:intro>`.
 
 When using the :func:`~handle_urls` decorator, its ``include``, ``exclude``,
 and ``priority`` parameters are used to create a :class:`~url_matcher.Patterns`
 object. When creating an :class:`~.ApplyRule` object manually, you must create
-a :class:`~url_matcher.Patterns` object manually and pass it to the
-``for_patterns`` parameter of :class:`~.ApplyRule`.
+a :class:`~url_matcher.Patterns` object and pass it to the ``for_patterns``
+parameter of :class:`~.ApplyRule`.
 
 
 .. _rule-precedence:
@@ -72,36 +92,45 @@ a :class:`~url_matcher.Patterns` object manually and pass it to the
 Rule precedence
 ---------------
 
-Often you define rules so that a given combination of input URL and
-:ref:`item type <item-types>` can only match 1 rule. However, there are
+Often you define rules so that a given user input, i.e. a combination of a
+target URL and an output class, can only match 1 rule. However, there are
 scenarios where it can be useful to define 2 or more rules that can all match a
-given combination.
+given user input.
 
 For example, you might want to define a “generic” page object class with some
 default implementation of field extraction, e.g. based on semantic markup or
-machine learning, and be able to replace it based on the input URL, e.g. for
+machine learning, and be able to override it based on the input URL, e.g. for
 specific websites or URL patterns, with a more specific page object class.
 
-For a given combination of input URL and item type, when 2 or more rules are a
-match, web-poet breaks the tie as follows:
+For a given user input, when 2 or more rules are a match, web-poet breaks the
+tie as follows:
 
--   One rule can indicate that it replaces the :ref:`page object class
-    <page-object-classes>` from another rule, taking precedence.
+-   One rule can indicate that its :ref:`page object class
+    <page-object-classes>` **overrides** another page object class.
 
     This is specified by :attr:`ApplyRule.instead_of <~.ApplyRule.instead_of>`.
     When using the :func:`~handle_urls` decorator, the value comes from the
     ``instead_of`` parameter of the decorator.
 
-    For example, the following page object would override ``MyPage`` from
+    For example, the following page object class would override ``MyPage`` from
     :ref:`above <handle_url_example>`:
 
     .. code-block:: python
 
         @handle_urls("example.com", instead_of=MyPage)
-        class ReplacementPage(ItemPage[MyItem]):
+        class OverridingPage(ItemPage[MyItem]):
             ...
 
--   One rule can declare a higher priority than another rule, taking
+    That is:
+
+    -   If the requested output class is ``MyPage``, an instance of
+        ``OverridingPage`` is returned instead.
+
+    -   If the requested output class is ``MyItem``, an instance of
+        ``OverridingPage`` is created, and used to build an instance of
+        ``MyItem``, which is returned.
+
+-   One rule can declare a higher **priority** than another rule, taking
     precedence.
 
     Rule priority is determined by the value of
@@ -109,8 +138,7 @@ match, web-poet breaks the tie as follows:
     When using the :func:`~handle_urls` decorator, the value comes from the
     ``priority`` parameter of the decorator. Rule priority is 500 by default.
 
-    For example, the following page object would override ``MyPage`` from
-    :ref:`above <handle_url_example>`:
+    For example, given the following page object class:
 
     .. code-block:: python
 
@@ -118,14 +146,28 @@ match, web-poet breaks the tie as follows:
         class PriorityPage(ItemPage[MyItem]):
             ...
 
-``instead_of`` triumphs ``priority``: If a rule replaces another rule using
-``instead_of``, it does not matter if the replaced rule had a higher priority.
+    The following would happen:
+
+    -   If the requested output class is ``MyItem``, an instance of
+        ``PriorityPage`` is created, and used to build an instance of
+        ``MyItem``, which is returned.
+
+    -   If the requested output class is ``MyPage``, an instance of
+        ``MyPage`` is returned, since ``PriorityPage`` is not defined as an
+        override for ``MyPage``.
+
+``instead_of`` triumphs ``priority``: If a rule overrides another rule using
+``instead_of``, it does not matter if the overridden rule had a higher
+priority.
+
+When multiple rules override the same page object class, through, ``priority``
+can break the tie.
 
 If none of those tie breakers are in place, the first rule added to the
 registry takes precedence. However, relying on registration order is
 discouraged, and you will get a warning if you register 2 or more rules with
-the same URL patterns, same output item type, same priority, and no
-``instead_of`` value.
+the same URL patterns, same output item class, same priority, and no
+``instead_of`` value. See also :ref:`rule-conflicts`.
 
 
 Rule registries
@@ -137,16 +179,13 @@ web-poet defines a default, global :class:`~.RulesRegistry` object at
 ``web_poet.default_registry``. Rules defined with the :func:`~.handle_urls`
 decorator are added to this registry.
 
-Using an alternative :class:`~.RulesRegistry` object is possible if your
-:ref:`framework <frameworks>` supports it.
-
 .. _load-rules:
 
 Loading rules
 -------------
 
 For a :ref:`framework <frameworks>` to apply your rules, you need to make sure
-that your code that adds those rules to the corresponding rules registry is
+that your code that adds those rules to ``web_poet.default_registry`` is
 executed.
 
 When using the :func:`~web_poet.handle_urls` decorator, that usually means that
@@ -164,3 +203,42 @@ point of your code for that:
 
 The ideal location for this function depends on your framework. Check the
 documentation of your framework for more information.
+
+
+.. _rule-conflicts:
+
+Rule conflicts
+==============
+
+A rule conflict occurs when multiple rules have the same ``instead_of`` and
+``priority`` values and can match the same URL.
+
+When it affects rules defined in your code base, solve the conflict adjusting
+those ``instead_of`` and ``priority`` values as needed.
+
+When it affects rules from a external package, you have the following options
+to solve the conflict:
+
+-   **Subclass** one of the conflicting page object classes in your code base,
+    using a similar rule except for a tie-breaking change to its ``instead_of``
+    or ``priority`` value.
+
+    For example, if ``package1.A`` and ``package2.B`` are page object classes
+    with conflicting rules, with a default priority (500), and you want
+    ``package1.A`` to take precedence, declare a new page object class as
+    follows:
+
+    .. code-block:: python
+
+        from package1 import A
+        from web_poet import handle_urls
+
+        @handle_urls(..., priority=501)
+        class NewA(A):
+            pass
+
+-   If your :ref:`framework <frameworks>` allows defining a **custom list of
+    rules**, you could use :class:`web_poet.default_registry <~.RulesRegistry>`
+    methods like :meth:`~.RulesRegistry.get_rules` or
+    :meth:`~.RulesRegistry.search` to build such a list, including only rules
+    that have no conflicts.

--- a/docs/page-objects/rules.rst
+++ b/docs/page-objects/rules.rst
@@ -143,7 +143,7 @@ tie as follows:
 
     .. code-block:: python
 
-        @handle_urls("example.com", priority=501)
+        @handle_urls("example.com", priority=510)
         class PriorityPage(ItemPage[MyItem]):
             ...
 
@@ -234,7 +234,7 @@ to solve the conflict:
         from package1 import A
         from web_poet import handle_urls
 
-        @handle_urls(..., priority=501)
+        @handle_urls(..., priority=510)
         class NewA(A):
             pass
 

--- a/docs/page-objects/rules.rst
+++ b/docs/page-objects/rules.rst
@@ -9,9 +9,10 @@ object class <page-object-classes>` to use based on user input, i.e. the target
 URL and an output class (a :ref:`page object class <page-object-classes>` or an
 :ref:`item class <items>`).
 
-Rules are necessary to enable using an item class as output class, and can also
-be useful as documentation or to get information about page object classes
-programmatically.
+Rules are necessary if you want to use an item class as output class, because
+they indicate which page object class to use to generate a given item class.
+Rules can also be useful as documentation or to get information about page
+object classes programmatically.
 
 :ref:`Rule precedence <rule-precedence>` can also be useful. For example, to
 implement generic page object classes that you can override for specific

--- a/docs/page-objects/rules.rst
+++ b/docs/page-objects/rules.rst
@@ -1,782 +1,166 @@
-.. _rules-intro:
+.. _rules:
 
-Apply rules
-===========
+=====
+Rules
+=====
 
-Basic Usage
------------
+Rules are :class:`~.ApplyRule` objects that tell web-poet which :ref:`page
+object class <page-object-classes>` to use for a given combination of input URL
+and :ref:`item type <item-types>`.
 
-@handle_urls
-~~~~~~~~~~~~
+Defining rules
+==============
 
-web-poet provides a :func:`~.handle_urls` decorator, which allows to
-declare how a page object can be used (applied):
+The :func:`~.handle_urls` decorator is the simplest way to define a rule for
+a page object. For example:
 
-* for which websites / URL patterns it works,
-* which data type (item classes) it can return,
-* which page objects it can replace (override; more on this later).
+.. _handle_url_example:
 
 .. code-block:: python
 
     from web_poet import ItemPage, handle_urls
+
     from my_items import MyItem
 
     @handle_urls("example.com")
     class MyPage(ItemPage[MyItem]):
-        # ...
+        ...
 
+The code above tells web-poet to use the ``MyPage`` :ref:`page object class
+<page-object-classes>` when given a URL pointing to the ``example.com`` domain
+name and being asked for an :ref:`item <items>` of type ``MyItem``.
 
-``handle_urls("example.com")`` can serve as documentation, but it also enables
-getting the information about page objects programmatically.
-The information about all page objects decorated with
-:func:`~.handle_urls` is stored in ``web_poet.default_registry``, which is
-an instance of :class:`~.RulesRegistry`. In the example above, the
-following :class:`~.ApplyRule` is added to the registry:
-
-.. code-block::
-
-    ApplyRule(
-        for_patterns=Patterns(include=('example.com',), exclude=(), priority=500),
-        use=<class 'MyPage'>,
-        instead_of=None,
-        to_return=<class 'my_items.MyItem'>,
-        meta={}
-    )
-
-Note how ``rule.to_return`` is set to ``MyItem`` automatically.
-Such rules can be used by libraries like `scrapy-poet`_. For example,
-if a spider needs to extract ``MyItem`` from some page on the ``example.com``
-website, `scrapy-poet`_ now knows that ``MyPage`` page object can be used.
-
-.. _scrapy-poet: https://scrapy-poet.readthedocs.io
-
-Specifying the URL patterns
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:func:`~handle_urls` decorator uses url-matcher_ library to define the
-URL rules. Some examples:
-
-.. code-block:: python
-
-    # page object can be applied on any URL from the example.com domain,
-    # or from any of its subdomains
-    @handle_urls("example.com")
-
-    # page object can be applied on example.com pages under /products/ path
-    @handle_urls("example.com/products/")
-
-    # page object can be applied on any URL from example.com, but only if
-    # it contains "productId=..." in the query string
-    @handle_urls("example.com?productId=*")
-
-The string passed to :func:`~.handle_urls` is converted to
-a :class:`url_matcher.matcher.Patterns` instance. Please consult
-with the url-matcher_ documentation to learn more about the possible rules;
-it is pretty flexible. You can exclude patterns, use wildcards,
-require certain query parameters to be present and ignore others, etc.
-Unlike regexes, this mini-language "understands" the URL structure.
-
-.. _url-matcher: https://url-matcher.readthedocs.io
-
-.. _rules-intro-overrides:
-
-Overrides
----------
-
-:func:`~.handle_urls` can be used to declare that a particular Page Object
-could (and should) be used *instead of* some other Page Object on
-certain URL patterns:
-
-.. code-block:: python
-
-    from web_poet import ItemPage, handle_urls
-    from my_items import Product
-    from my_pages import DefaultProductPage
-
-    @handle_urls("site1.example.com", instead_of=DefaultProductPage)
-    class Site1ProductPage(ItemPage[Product]):
-        # ...
-
-    @handle_urls("site2.example.com", instead_of=DefaultProductPage)
-    class Site2ProductPage(ItemPage[Product]):
-        # ...
-
-This concept is a bit more advanced than the basic ``handle_urls`` usage
-("this Page Object can return ``MyItem`` on example.com website").
-
-A common use case is a "generic", or a "template" spider, which uses some
-default implementation of the extraction, and allows to replace it
-("override") on specific websites or URL patterns.
-
-This default page extraction (``DefaultProductPage`` in the example) can be based on
-semantic markup, Machine Learning, heuristics, or just be empty. Page Objects which
-can be used instead of the default (``Site1ProductPage``, ``Site2ProductPage``)
-are commonly written using XPath or CSS selectors, with website-specific rules.
-
-Libraries like scrapy-poet_ allow to create such "generic" spiders by
-using the information declared via ``handle_urls(..., instead_of=...)``.
-
-Example Use Case
-~~~~~~~~~~~~~~~~
-
-Let's explore an example use case for the Overrides concept.
-
-Suppose we're using Page Objects for our broadcrawl project which explores
-eCommerce websites to discover product pages. It wouldn't be entirely possible
-for us to create parsers for all websites since we don't know which sites we're
-going to crawl beforehand.
-
-However, we could at least create a generic Page Object to support parsing of
-some fields in well-known locations of product information like ``<title>``.
-This enables our broadcrawler to at least parse some useful information. Let's
-call such a Page Object to be ``GenericProductPage``.
-
-Assuming that one of our project requirements is to fully support parsing of the
-`top 3 eCommerce websites`, then we'd need to create a Page Object for each one
-to parse more specific fields.
-
-Here's where the Overrides concept comes in:
-
-    1. The ``GenericProductPage`` is used to parse all eCommerce product pages
-       `by default`.
-    2. Whenever one of our declared URL rules matches with a given page URL,
-       then the Page Object associated with that rule `overrides (or replaces)`
-       the default ``GenericProductPage``.
-
-This enables us to conveniently declare which Page Object would be used for a
-given webpage `(based on a page's URL pattern)`.
-
-Let's see this in action by declaring the Overrides in the Page Objects below.
-
-
-Creating Overrides
-~~~~~~~~~~~~~~~~~~
-
-To simplify the code examples in the next few subsections, let's assume that
-these item classes have been predefined:
-
-.. code-block:: python
-
-    import attrs
-
-
-    @attrs.define
-    class Product:
-        product_title: str
-        regular_price: float
-
-
-    @attrs.define
-    class SimilarProduct:
-        product_title: str
-        regular_price: float
-
-Page Object
-"""""""""""
-
-Let's take a look at how the following code is structured:
-
-.. code-block:: python
-
-    from web_poet import handle_urls, WebPage, validates_input
-
-
-    class GenericProductPage(WebPage):
-        @validates_input
-        def to_item(self) -> Product:
-            return Product(product_title=self.css("title::text").get())
-
-
-    @handle_urls("some.example", instead_of=GenericProductPage)
-    class ExampleProductPage(WebPage):
-        ...  # more specific parsing
-
-
-    @handle_urls("another.example", instead_of=GenericProductPage, exclude="/digital-goods/")
-    class AnotherExampleProductPage(WebPage):
-        ...  # more specific parsing
-
-
-    @handle_urls(["dual.example/shop/?product=*", "uk.dual.example/store/?pid=*"], instead_of=GenericProductPage)
-    class DualExampleProductPage(WebPage):
-        ...  # more specific parsing
-
-The code above declares that:
-
-    - The Page Objects return ``Product`` and ``SimilarProduct`` item classes.
-      Returning item classes is a preferred approach as explained in the
-      :ref:`fields` section.
-    - For sites that match the ``some.example`` pattern, ``ExampleProductPage``
-      would be used instead of ``GenericProductPage``.
-    - The same is true for ``DualExampleProductPage`` where it is used
-      instead of ``GenericProductPage`` for two URL patterns which works as
-      something like:
-
-      - :sub:`(match) https://www.dual.example/shop/electronics/?product=123`
-      - :sub:`(match) https://www.dual.example/shop/books/paperback/?product=849`
-      - :sub:`(NO match) https://www.dual.example/on-sale/books/?product=923`
-      - :sub:`(match) https://www.uk.dual.example/store/kitchen/?pid=776`
-      - :sub:`(match) https://www.uk.dual.example/store/?pid=892`
-      - :sub:`(NO match) https://www.uk.dual.example/new-offers/fitness/?pid=892`
-
-    - On the other hand, ``AnotherExampleProductPage`` is used instead of
-      ``GenericProductPage`` when we're handling pages that match the
-      ``another.example`` URL Pattern, which doesn't contain
-      ``/digital-goods/`` in its URL path.
-
-.. tip::
-
-    The URL patterns declared in the ``@handle_urls`` decorator can still be
-    further customized. You can read some of the specific parameters in the
-    :ref:`API section <api-rules>` of :func:`web_poet.handle_urls`.
-
-.. _rules-item-class-example:
-
-Item Class
-""""""""""
-
-An alternative approach for the Page Object Overrides example above is to specify
-the returned item class. For example, we could change the previous example into
-the following:
-
-
-.. code-block:: python
-
-    from web_poet import handle_urls, WebPage, validates_input
-
-
-    class GenericProductPage(WebPage[Product]):
-        @validates_input
-        def to_item(self) -> Product:
-            return Product(product_title=self.css("title::text").get())
-
-
-    @handle_urls("some.example")
-    class ExampleProductPage(WebPage[Product]):
-        ...  # more specific parsing
-
-
-    @handle_urls("another.example", exclude="/digital-goods/")
-    class AnotherExampleProductPage(WebPage[Product]):
-        ...  # more specific parsing
-
-
-    @handle_urls(["dual.example/shop/?product=*", "uk.dual.example/store/?pid=*"])
-    class DualExampleProductPage(WebPage[Product]):
-        ...  # more specific parsing
-
-Let's break this example down:
-
-    - The URL patterns are exactly the same as with the previous code example.
-    - The ``@handle_urls`` decorator determines the item class to return (i.e.
-      ``Product``) from the decorated Page Object.
-    - The ``instead_of`` parameter can be omitted in lieu of the derived Item
-      Class from the Page Object which becomes the ``to_return`` attribute in
-      :class:`~.ApplyRule` instances. This means that:
-
-        - If a ``Product`` item class is requested for URLs matching with the
-          "some.example" pattern, then the ``Product`` item class would come from
-          the ``to_item()`` method of ``ExampleProductPage``.
-        - Similarly, if a page with a URL matches with "another.example" without
-          the "/digital-goods/" path, then the ``Product`` item class comes from
-          the ``AnotherExampleProductPage`` Page Object.
-        - However, if a ``Product`` item class is requested matching with the URL
-          pattern of "dual.example/shop/?product=*", a ``SimilarProduct``
-          item class is returned by the ``DualExampleProductPage``'s ``to_item()``
-          method instead.
-
-Specifying the item class that a Page Object returns makes it possible for
-web-poet frameworks to make Page Object usage transparent to end users.
-
-For example, a web-poet framework could implement a function like:
-
-.. code-block:: python
-
-    item = get_item(url, item_class=Product)
-
-Here there is no reference to the Page Object being used underneath, you only
-need to indicate the desired item class, and the web-poet framework
-automatically determines the Page Object to use based on the specified URL and
-the specified item class.
-
-Note, however, that web-poet frameworks are encouraged to also allow getting a
-Page Object instead of an item class instance, for scenarios where end users
-wish access to Page Object attributes and methods.
-
-
-.. _rules-combination:
-
-Combination
-"""""""""""
-
-Of course, you can use the combination of both which enables you to specify in
-either contexts of Page Objects and item classes.
-
-.. code-block:: python
-
-    from web_poet import handle_urls, WebPage, validates_input
-
-
-    class GenericProductPage(WebPage[Product]):
-        @validates_input
-        def to_item(self) -> Product:
-            return Product(product_title=self.css("title::text").get())
-
-
-    @handle_urls("some.example", instead_of=GenericProductPage)
-    class ExampleProductPage(WebPage[Product]):
-        ...  # more specific parsing
-
-
-    @handle_urls("another.example", instead_of=GenericProductPage, exclude="/digital-goods/")
-    class AnotherExampleProductPage(WebPage[Product]):
-        ...  # more specific parsing
-
-
-    @handle_urls(["dual.example/shop/?product=*", "uk.dual.example/store/?pid=*"], instead_of=GenericProductPage)
-    class DualExampleProductPage(WebPage[SimilarProduct]):
-        ...  # more specific parsing
-
-See the next :ref:`rules-retrieving` section to observe what are the actual
-:class:`~.ApplyRule` that were created by the ``@handle_urls`` decorators.
-
-Working with rules
-------------------
-
-.. _rules-retrieving:
-
-Retrieving all available rules
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The :meth:`~.RulesRegistry.get_rules` method from the ``web_poet.default_registry``
-allows retrieval of all :class:`~.ApplyRule` in the given registry.
-Following from our example above in the :ref:`rules-combination` section, using it
-would be:
-
-.. code-block:: python
-
-    from web_poet import default_registry
-
-    # Retrieves all ApplyRules that were registered in the registry
-    rules = default_registry.get_rules()
-
-    for r in rules:
-        print(r)
-    # ApplyRule(for_patterns=Patterns(include=('some.example',), exclude=(), priority=500), use=<class 'ExampleProductPage'>, instead_of=<class 'GenericProductPage'>, to_return=<class 'Product'>, meta={})
-    # ApplyRule(for_patterns=Patterns(include=('another.example',), exclude=('/digital-goods/',), priority=500), use=<class 'AnotherExampleProductPage'>, instead_of=<class 'GenericProductPage'>, to_return=<class 'Product'>, meta={})
-    # ApplyRule(for_patterns=Patterns(include=('dual.example/shop/?product=*', 'uk.dual.example/store/?pid=*'), exclude=(), priority=500), use=<class 'DualExampleProductPage'>, instead_of=<class 'GenericProductPage'>, to_return=<class 'SimilarProduct'>, meta={})
-
-Remember that using ``@handle_urls`` to annotate the Page Objects would result
-in the :class:`~.ApplyRule` to be written into ``web_poet.default_registry``.
-
-
-.. warning::
-
-    :meth:`~.RulesRegistry.get_rules` relies on the fact that all essential
-    packages/modules which contains the :func:`web_poet.handle_urls`
-    decorators are properly loaded `(i.e imported)`.
-
-    Thus, for cases like importing and using Page Objects from other external packages,
-    the ``@handle_urls`` decorators from these external sources must be read and
-    processed properly. This ensures that the external Page Objects have all of their
-    :class:`~.ApplyRule` present.
-
-    This can be done via the function named :func:`~.web_poet.rules.consume_modules`.
-    Here's an example:
-
-    .. code-block:: python
-
-        from web_poet import default_registry, consume_modules
-
-        consume_modules("external_package_A.po", "another_ext_package.lib")
-        rules = default_registry.get_rules()
-
-    The next section explores this caveat further.
-
-Using URLs against the registered rules
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-One of the important aspects of :class:`~.ApplyRule` is dictating which URLs it's
-able to work using its ``for_patterns`` attribute. There are a few methods
-available in :class:`~.RulesRegistry` which accepts a URL value (:class:`str`,
-:class:`~.RequestUrl`, or :class:`~.ResponseUrl`) to find specific information
-from the registered rules.
-
-.. _rules-overrides_for-example:
-
-Find the page object overrides
-""""""""""""""""""""""""""""""
-
-Suppose you want to see what are the :ref:`rules-intro-overrides` that are
-available from a given webpage, you can use :meth:`~.RulesRegistry.overrides_for`
-by passing the webpage URL. For example:
-
-.. code-block:: python
-
-    from web_poet import default_registry
-
-    overrides = default_registry.overrides_for("http://books.toscrape.com/")
-    print(overrides)
-
-    # {
-    #     <class 'OldProductPage'>: <class 'NewProductPage'>,
-    #     <class 'OverriddenPage'>: <class 'UseThisPage'>,
-    # }
-
-It returns a :class:`Mapping` where the *key* represents the page object class
-that is overridden or replaced by the page object class in the *value*.
-
-.. _rules-page_cls_for_item-example:
-
-Identify the page object that could create the item
-"""""""""""""""""""""""""""""""""""""""""""""""""""
-
-Suppose you want to retrieve the page object class that is able to create the
-item class that you want from a given webpage, you can use
-:meth:`~.RulesRegistry.page_cls_for_item`. For example:
-
-.. code-block:: python
-
-    from web_poet import default_registry
-
-    page_cls = default_registry.page_cls_for_item(
-        "http://books.toscrape.com/catalogue/sapiens-a-brief-history-of-humankind_996/index.html",
-        Book
-    )
-    print(page_cls)  # BookPage
-
-
-Using rules from External Packages
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Developers have the option to import existing Page Objects alongside the
-:class:`~.ApplyRule` attached to them. This section aims to showcase different
-scenarios that come up when using multiple Page Object Projects.
-
-.. _rules-using-all:
-
-Using all available ApplyRules from multiple Page Object Projects
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-Let's suppose we have the following use case before us:
-
-    - An **external** Python package named ``ecommerce_page_objects`` is available
-      which contains Page Objects for common websites.
-    - Another similar **external** package named ``gadget_sites_page_objects`` is
-      available for even more specific websites.
-    - Your project's objective is to handle as much eCommerce websites as you
-      can.
-
-        - Thus, you'd want to use the already available packages above and
-          perhaps improve on them or create new Page Objects for new websites.
-
-Remember that all of the :class:`~.ApplyRule` are declared by annotating
-Page Objects using the :func:`web_poet.handle_urls` via ``@handle_urls``. Thus,
-they can easily be accessed using the :meth:`~.RulesRegistry.get_rules`
-of ``web_poet.default_registry``.
-
-This can be done something like:
-
-.. code-block:: python
-
-    from web_poet import default_registry, consume_modules
-
-    # ❌ Remember that this wouldn't retrieve any rules at all since the
-    # ``@handle_urls`` decorators are NOT properly loaded.
-    rules = default_registry.get_rules()
-    print(rules)  # []
-
-    # ✅ Instead, you need to run the following so that all of the Page
-    # Objects in the external packages are recursively imported.
-    consume_modules("ecommerce_page_objects", "gadget_sites_page_objects")
-    rules = default_registry.get_rules()
-
-    # The collected rules would then be as follows:
-    print(rules)
-    # 1. ApplyRule(for_patterns=Patterns(include=['site_1.example'], exclude=[], priority=500), use=<class 'ecommerce_page_objects.site_1.EcomSite1'>, instead_of=<class 'ecommerce_page_objects.EcomGenericPage'>, to_return=None, meta={})
-    # 2. ApplyRule(for_patterns=Patterns(include=['site_2.example'], exclude=[], priority=500), use=<class 'ecommerce_page_objects.site_2.EcomSite2'>, instead_of=<class 'ecommerce_page_objects.EcomGenericPage'>, to_return=None, meta={})
-    # 3. ApplyRule(for_patterns=Patterns(include=['site_2.example'], exclude=[], priority=500), use=<class 'gadget_sites_page_objects.site_2.GadgetSite2'>, instead_of=<class 'gadget_sites_page_objects.GadgetGenericPage'>, to_return=None, meta={})
-    # 4. ApplyRule(for_patterns=Patterns(include=['site_3.example'], exclude=[], priority=500), use=<class 'gadget_sites_page_objects.site_3.GadgetSite3'>, instead_of=<class 'gadget_sites_page_objects.GadgetGenericPage'>, to_return=None, meta={})
-
-.. note::
-
-    Once :func:`~.web_poet.rules.consume_modules` is called, then all
-    external Page Objects are recursively imported and available for the entire
-    runtime duration. Calling :func:`~.web_poet.rules.consume_modules` again
-    makes no difference unless a new set of modules are provided.
-
-.. _rules-using-subset:
-
-Using only a subset of the available ApplyRules
-"""""""""""""""""""""""""""""""""""""""""""""""
-
-Suppose that the use case from the previous section has changed wherein a
-subset of :class:`~.ApplyRule` would be used. This could be achieved by
-using the :meth:`~.RulesRegistry.search` method which allows for
-convenient selection of a subset of rules from a given registry.
-
-Here's an example of how you could manually select the rules using the
-:meth:`~.RulesRegistry.search` method instead:
-
-.. code-block:: python
-
-    from web_poet import default_registry, consume_modules
-    import ecommerce_page_objects, gadget_sites_page_objects
-
-    consume_modules("ecommerce_page_objects", "gadget_sites_page_objects")
-
-    ecom_rules = default_registry.search(instead_of=ecommerce_page_objects.EcomGenericPage)
-    print(ecom_rules)
-    # ApplyRule(for_patterns=Patterns(include=['site_1.example'], exclude=[], priority=500), use=<class 'ecommerce_page_objects.site_1.EcomSite1'>, instead_of=<class 'ecommerce_page_objects.EcomGenericPage'>, to_return=None, meta={})
-    # ApplyRule(for_patterns=Patterns(include=['site_2.example'], exclude=[], priority=500), use=<class 'ecommerce_page_objects.site_2.EcomSite2'>, instead_of=<class 'ecommerce_page_objects.EcomGenericPage'>, to_return=None, meta={})
-
-    gadget_rules = default_registry.search(use=gadget_sites_page_objects.site_3.GadgetSite3)
-    print(gadget_rules)
-    # ApplyRule(for_patterns=Patterns(include=['site_3.example'], exclude=[], priority=500), use=<class 'gadget_sites_page_objects.site_3.GadgetSite3'>, instead_of=<class 'gadget_sites_page_objects.GadgetGenericPage'>, to_return=None, meta={})
-
-    rules = ecom_rules + gadget_rules
-    print(rules)
-    # ApplyRule(for_patterns=Patterns(include=['site_1.example'], exclude=[], priority=500), use=<class 'ecommerce_page_objects.site_1.EcomSite1'>, instead_of=<class 'ecommerce_page_objects.EcomGenericPage'>, to_return=None, meta={})
-    # ApplyRule(for_patterns=Patterns(include=['site_2.example'], exclude=[], priority=500), use=<class 'ecommerce_page_objects.site_2.EcomSite2'>, instead_of=<class 'ecommerce_page_objects.EcomGenericPage'>, to_return=None, meta={})
-    # ApplyRule(for_patterns=Patterns(include=['site_3.example'], exclude=[], priority=500), use=<class 'gadget_sites_page_objects.site_3.GadgetSite3'>, instead_of=<class 'gadget_sites_page_objects.GadgetGenericPage'>, to_return=None, meta={})
-
-As you can see, using the :meth:`~.RulesRegistry.search` method allows you to
-conveniently select for :class:`~.ApplyRule` which conform to a specific criteria. This
-allows you to conveniently drill down to which :class:`~.ApplyRule` you're interested in
-using.
-
-.. _rules-custom-registry:
-
-Creating a new registry
-"""""""""""""""""""""""
-
-After gathering all the pre-selected rules, we can then store it in a new instance
-of :class:`~.RulesRegistry` in order to separate it from the ``default_registry``
-which contains all of the rules. We can use the ``RulesRegistry(rules=...)``
-for this:
-
-.. code-block:: python
-
-    from web_poet import RulesRegistry
-
-    my_new_registry = RulesRegistry(rules=rules)
-
-
-.. _rules-improve-po:
-
-Improving on external Page Objects
-""""""""""""""""""""""""""""""""""
-
-There would be cases wherein you're using Page Objects with :class:`~.ApplyRule`
-from external packages only to find out that a few of them lacks some of the
-fields or features that you need.
-
-Let's suppose that we wanted to use `all` of the :class:`~.ApplyRule` similar
-to this section: :ref:`rules-using-all`. However, the ``EcomSite1`` Page Object
-needs to properly handle some edge cases where some fields are not being extracted
-properly. One way to fix this is to subclass the said Page Object and improve its
-``to_item()`` method, or even creating a new class entirely. For simplicity, let's
-have the first approach as an example:
-
-.. code-block:: python
-
-    from web_poet import default_registry, consume_modules, handle_urls, validates_input
-    import ecommerce_page_objects, gadget_sites_page_objects
-
-    consume_modules("ecommerce_page_objects", "gadget_sites_page_objects")
-    rules = default_registry.get_rules()
-
-    # The collected rules would then be as follows:
-    print(rules)
-    # 1. ApplyRule(for_patterns=Patterns(include=['site_1.example'], exclude=[], priority=500), use=<class 'ecommerce_page_objects.site_1.EcomSite1'>, instead_of=<class 'ecommerce_page_objects.EcomGenericPage'>, to_return=None, meta={})
-    # 2. ApplyRule(for_patterns=Patterns(include=['site_2.example'], exclude=[], priority=500), use=<class 'ecommerce_page_objects.site_2.EcomSite2'>, instead_of=<class 'ecommerce_page_objects.EcomGenericPage'>, to_return=None, meta={})
-    # 3. ApplyRule(for_patterns=Patterns(include=['site_2.example'], exclude=[], priority=500), use=<class 'gadget_sites_page_objects.site_2.GadgetSite2'>, instead_of=<class 'gadget_sites_page_objects.GadgetGenericPage'>, to_return=None, meta={})
-    # 4. ApplyRule(for_patterns=Patterns(include=['site_3.example'], exclude=[], priority=500), use=<class 'gadget_sites_page_objects.site_3.GadgetSite3'>, instead_of=<class 'gadget_sites_page_objects.GadgetGenericPage'>, to_return=None, meta={})
-
-    @handle_urls("site_1.example", instead_of=ecommerce_page_objects.EcomGenericPage, priority=1000)
-    class ImprovedEcomSite1(ecommerce_page_objects.site_1.EcomSite1):
-        @validates_input
-        def to_item(self):
-            ...  # call super().to_item() and improve on the item's shortcomings
-
-    rules = default_registry.get_rules()
-    print(rules)
-    # 1. ApplyRule(for_patterns=Patterns(include=['site_1.example'], exclude=[], priority=500), use=<class 'ecommerce_page_objects.site_1.EcomSite1'>, instead_of=<class 'ecommerce_page_objects.EcomGenericPage'>, to_return=None, meta={})
-    # 2. ApplyRule(for_patterns=Patterns(include=['site_2.example'], exclude=[], priority=500), use=<class 'ecommerce_page_objects.site_2.EcomSite2'>, instead_of=<class 'ecommerce_page_objects.EcomGenericPage'>, to_return=None, meta={})
-    # 3. ApplyRule(for_patterns=Patterns(include=['site_2.example'], exclude=[], priority=500), use=<class 'gadget_sites_page_objects.site_2.GadgetSite2'>, instead_of=<class 'gadget_sites_page_objects.GadgetGenericPage'>, to_return=None, meta={})
-    # 4. ApplyRule(for_patterns=Patterns(include=['site_3.example'], exclude=[], priority=500), use=<class 'gadget_sites_page_objects.site_3.GadgetSite3'>, instead_of=<class 'gadget_sites_page_objects.GadgetGenericPage'>, to_return=None, meta={})
-    # 5. ApplyRule(for_patterns=Patterns(include=['site_1.example'], exclude=[], priority=1000), use=<class 'my_project.ImprovedEcomSite1'>, instead_of=<class 'ecommerce_page_objects.EcomGenericPage'>, to_return=None, meta={})
-
-Notice that we're adding a new :class:`~.ApplyRule` for the same URL pattern
-for ``site_1.example``.
-
-When the time comes that a Page Object needs to be selected when parsing ``site_1.example``
-and it needs to replace ``ecommerce_page_objects.EcomGenericPage``, rules **#1**
-and **#5** will be the choices. However, since we've assigned a much **higher priority**
-for the new rule in **#5** than the default ``500`` value,  rule **#5** will be
-chosen because of its higher priority value.
-
-More details on this in the :ref:`Priority Resolution <rules-priority-resolution>`
-subsection.
-
-
-Handling conflicts when using Multiple External Packages
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-You might've observed from the previous section that retrieving the list of all
-:class:`~.ApplyRule` from two different external packages may result in a
-conflict.
-
-We can take a look at the rules for **#2** and **#3** when we were importing all
-available rules:
-
-.. code-block:: python
-
-    # 2. ApplyRule(for_patterns=Patterns(include=['site_2.example'], exclude=[], priority=500), use=<class 'ecommerce_page_objects.site_2.EcomSite2'>, instead_of=<class 'ecommerce_page_objects.EcomGenericPage'>, to_return=None, meta={})
-    # 3. ApplyRule(for_patterns=Patterns(include=['site_2.example'], exclude=[], priority=500), use=<class 'gadget_sites_page_objects.site_2.GadgetSite2'>, instead_of=<class 'gadget_sites_page_objects.GadgetGenericPage'>, to_return=None, meta={})
-
-However, it's technically **NOT** a `conflict`, **yet**, since:
-
-    - ``ecommerce_page_objects.site_2.EcomSite2`` would only be used in **site_2.example**
-      if ``ecommerce_page_objects.EcomGenericPage`` is to be replaced.
-    - The same case with ``gadget_sites_page_objects.site_2.GadgetSite2`` wherein
-      it's only going to be utilized for **site_2.example** if the following is to be
-      replaced: ``gadget_sites_page_objects.GadgetGenericPage``.
-
-It would be only become a conflict if both rules for **site_2.example** `intend to
-replace the` **same** `Page Object`.
-
-However, let's suppose that there are some :class:`~.ApplyRule` which actually
-result in a conflict. To give an example, let's suppose that rules **#2** and **#3**
-`intends to replace the` **same** `Page Object`. It would look something like:
-
-.. code-block:: python
-
-    # 2. ApplyRule(for_patterns=Patterns(include=['site_2.example'], exclude=[], priority=500), use=<class 'ecommerce_page_objects.site_2.EcomSite2'>, instead_of=<class 'common_items.ProductGenericPage'>, to_return=None, meta={})
-    # 3. ApplyRule(for_patterns=Patterns(include=['site_2.example'], exclude=[], priority=500), use=<class 'gadget_sites_page_objects.site_2.GadgetSite2'>, instead_of=<class 'common_items.ProductGenericPage'>, to_return=None, meta={})
-
-Notice that the ``instead_of`` param are the same and only the ``use`` param
-remained different.
-
-There are two main ways we recommend in solving this.
-
-.. _rules-priority-resolution:
-
-**1. Priority Resolution**
-
-If you notice, the ``for_patterns`` attribute of :class:`~.ApplyRule` is an
-instance of `url_matcher.Patterns
-<https://url-matcher.readthedocs.io/en/stable/api_reference.html#module-url-matcher>`_.
-This instance also has a ``priority`` param where a higher value will be chosen
-in times of conflict.
-
-.. note::
-
-    The `url-matcher`_ library is the one responsible breaking such ``priority`` conflicts
-    `(amongst others)`. It's specifically discussed in this section: `rules-conflict-resolution
-    <https://url-matcher.readthedocs.io/en/stable/intro.html#rules-conflict-resolution>`_.
-
-Unfortunately, updating the ``priority`` value directly isn't possible as the
-:class:`url_matcher.Patterns` is a **frozen** `dataclass`. The same is true for
-:class:`~.ApplyRule`. This is made by design so that they are hashable and could
-be deduplicated immediately without consequences of them changing in value.
-
-The only way that the ``priority`` value can be changed is by creating a new
-:class:`~.ApplyRule` with a different ``priority`` value (`higher if it needs
-more priority`). You don't necessarily need to `delete` the **old**
-:class:`~.ApplyRule` since they will be resolved via ``priority`` anyways.
-
-Creating a new :class:`~.ApplyRule` with a higher priority could be as easy as:
-
-    1. Subclassing the Page Object in question.
-    2. Declare a new :func:`web_poet.handle_urls` decorator with the same URL
-       pattern and Page Object to override but with a much higher priority.
-
-Here's an example:
-
-.. code-block:: python
-
-    from web_poet import default_registry, consume_modules, handle_urls, validates_input
-    import ecommerce_page_objects, gadget_sites_page_objects, common_items
-
-    @handle_urls("site_2.example", instead_of=common_items.ProductGenericPage, priority=1000)
-    class EcomSite2Copy(ecommerce_page_objects.site_1.EcomSite1):
-        @validates_input
-        def to_item(self):
-            return super().to_item()
-
-Now, the conflicting **#2** and **#3** rules would never be selected because of
-the new :class:`~.ApplyRule` having a much higher priority (see rule **#4**):
-
-.. code-block:: python
-
-    # 2. ApplyRule(for_patterns=Patterns(include=['site_2.example'], exclude=[], priority=500), use=<class 'ecommerce_page_objects.site_2.EcomSite2'>, instead_of=<class 'common_items.ProductGenericPage'>, to_return=None, meta={})
-    # 3. ApplyRule(for_patterns=Patterns(include=['site_2.example'], exclude=[], priority=500), use=<class 'gadget_sites_page_objects.site_2.GadgetSite2'>, instead_of=<class 'common_items.ProductGenericPage'>, to_return=None, meta={})
-
-    # 4. ApplyRule(for_patterns=Patterns(include=['site_2.example'], exclude=[], priority=1000), use=<class 'my_project.EcomSite2Copy'>, instead_of=<class 'common_items.ProductGenericPage'>, to_return=None, meta={})
-
-A similar idea was also discussed in the :ref:`rules-improve-po` section.
-
-
-**2. Specifically Selecting the Rules**
-
-When the last resort of ``priority``-resolution doesn't work, then you could always
-specifically select the list of :class:`~.ApplyRule` you want to use.
-
-We **recommend** in creating an **inclusion**-list rather than an **exclusion**-list
-since the latter is quite brittle. For instance, an external package you're using
-has updated its rules and the exlusion strategy misses out on a few rules that
-were recently added. This could lead to a `silent-error` of receiving a different
-set of rules than expected.
-
-This **inclusion**-list approach can be done by importing the Page Objects directly
-and creating instances of :class:`~.ApplyRule` from it. You could also import
-all of the available :class:`~.ApplyRule` using :meth:`~.RulesRegistry.get_rules`
-to sift through the list of available rules and manually selecting the rules you need.
-
-Most of the time, the needed rules are the ones which uses the Page Objects we're
-interested in. You can use :meth:`~.RulesRegistry.search` to get
-them (see :ref:`rules-using-subset`):
-
-.. code-block:: python
-
-    from web_poet import default_registry, consume_modules
-    import package_A, package_B, package_C
-
-    consume_modules("package_A", "package_B", "package_C")
-
-    rules = default_registry.search(use=package_A.PageObject1) + \
-            default_registry.search(use=package_B.PageObject2) + \
-            default_registry.search(use=package_C.PageObject3)
-
-    # ApplyRule(for_patterns=Patterns(include=['site_A.example'], exclude=[], priority=500), use=<class 'package_A.PageObject1'>, instead_of=<class 'GenericPage'>, to_return=None, meta={})
-    # ApplyRule(for_patterns=Patterns(include=['site_B.example'], exclude=[], priority=500), use=<class 'package_B.PageObject2'>, instead_of=<class 'GenericPage'>, to_return=None, meta={})
-    # ApplyRule(for_patterns=Patterns(include=['site_C.example'], exclude=[], priority=500), use=<class 'package_C.PageObject3'>, instead_of=<class 'GenericPage'>, to_return=None, meta={})
-
-
-Another example:
+Alternatively, you can manually create and register :class:`~.ApplyRule`
+objects:
 
 .. code-block:: python
 
     from url_matcher import Patterns
-    from web_poet import default_registry, consume_modules
-    import package_A, package_B, package_C
+    from web_poet import ApplyRule, ItemPage, default_registry
 
-    consume_modules("package_A", "package_B", "package_C")
+    from my_items import MyItem
 
-    rule_from_A = default_registry.search(use=package_A.PageObject1)
-    print(rule_from_A)
-    # [ApplyRule(for_patterns=Patterns(include=['site_A.example'], exclude=[], priority=500), use=<class 'package_A.PageObject1'>, instead_of=<class 'GenericPage'>, to_return=None, meta={})]
+    class MyPage(ItemPage[MyItem]):
+        ...
 
-    rule_from_B = default_registry.search(instead_of=GenericProductPage)
-    print(rule_from_B)
-    # []
+    rule = ApplyRule(
+        for_patterns=Patterns(include=['example.com']),
+        use=MyPage,
+        to_return=MyItem,
+    )
+    default_registry.add_rule(rule)
 
-    rule_from_C = default_registry.search(for_patterns=Patterns(include=["site_C.example"]))
-    print(rule_from_C)
-    # [
-    #     ApplyRule(for_patterns=Patterns(include=['site_C.example'], exclude=[], priority=500), use=<class 'package_C.PageObject3'>, instead_of=<class 'GenericPage'>, to_return=None, meta={}),
-    #     ApplyRule(for_patterns=Patterns(include=['site_C.example'], exclude=[], priority=1000), use=<class 'package_C.PageObject3_improved'>, instead_of=<class 'GenericPage'>, to_return=None, meta={})
-    # ]
+URL patterns
+------------
 
-    rules = rule_from_A + rule_from_B + rule_from_C
+Every rule defines a :class:`url_matcher.Patterns` object that determines if
+any given URL is a match for the rule.
+
+:class:`~url_matcher.Patterns` objects offer a simple but powerful syntax for
+URL matching. For details and examples, see the :ref:`url-matcher documentation
+<url-matcher:intro>`.
+
+When using the :func:`~handle_urls` decorator, its ``include``, ``exclude``,
+and ``priority`` parameters are used to create a :class:`~url_matcher.Patterns`
+object. When creating an :class:`~.ApplyRule` object manually, you must create
+a :class:`~url_matcher.Patterns` object manually and pass it to the
+``for_patterns`` parameter of :class:`~.ApplyRule`.
+
+
+.. _rule-precedence:
+
+Rule precedence
+---------------
+
+Often you define rules so that a given combination of input URL and
+:ref:`item type <item-types>` can only match 1 rule. However, there are
+scenarios where it can be useful to define 2 or more rules that can all match a
+given combination.
+
+For example, you might want to define a “generic” page object class with some
+default implementation of field extraction, e.g. based on semantic markup or
+machine learning, and be able to replace it based on the input URL, e.g. for
+specific websites or URL patterns, with a more specific page object class.
+
+For a given combination of input URL and item type, when 2 or more rules are a
+match, web-poet breaks the tie as follows:
+
+-   One rule can indicate that it replaces the :ref:`page object class
+    <page-object-classes>` from another rule, taking precedence.
+
+    This is specified by :attr:`ApplyRule.instead_of <~.ApplyRule.instead_of>`.
+    When using the :func:`~handle_urls` decorator, the value comes from the
+    ``instead_of`` parameter of the decorator.
+
+    For example, the following page object would override ``MyPage`` from
+    :ref:`above <handle_url_example>`:
+
+    .. code-block:: python
+
+        @handle_urls("example.com", instead_of=MyPage)
+        class ReplacementPage(ItemPage[MyItem]):
+            ...
+
+-   One rule can declare a higher priority than another rule, taking
+    precedence.
+
+    Rule priority is determined by the value of
+    :attr:`ApplyRule.for_patterns.priority <url_matcher.Patterns.priority>`.
+    When using the :func:`~handle_urls` decorator, the value comes from the
+    ``priority`` parameter of the decorator. Rule priority is 500 by default.
+
+    For example, the following page object would override ``MyPage`` from
+    :ref:`above <handle_url_example>`:
+
+    .. code-block:: python
+
+        @handle_urls("example.com", priority=501)
+        class PriorityPage(ItemPage[MyItem]):
+            ...
+
+``instead_of`` triumphs ``priority``: If a rule replaces another rule using
+``instead_of``, it does not matter if the replaced rule had a higher priority.
+
+If none of those tie breakers are in place, the first rule added to the
+registry takes precedence. However, relying on registration order is
+discouraged, and you will get a warning if you register 2 or more rules with
+the same URL patterns, same output item type, same priority, and no
+``instead_of`` value.
+
+
+Rule registries
+===============
+
+Rules should be stored in a :class:`~.RulesRegistry` object.
+
+web-poet defines a default, global :class:`~.RulesRegistry` object at
+``web_poet.default_registry``. Rules defined with the :func:`~.handle_urls`
+decorator are added to this registry.
+
+Using an alternative :class:`~.RulesRegistry` object is possible if your
+:ref:`framework <frameworks>` supports it.
+
+.. _load-rules:
+
+Loading rules
+-------------
+
+For a :ref:`framework <frameworks>` to apply your rules, you need to make sure
+that your code that adds those rules to the corresponding rules registry is
+executed.
+
+When using the :func:`~web_poet.handle_urls` decorator, that usually means that
+you need to make sure that Python imports the files where the decorator is
+used.
+
+You can use the :func:`~.web_poet.rules.consume_modules` function in some entry
+point of your code for that:
+
+.. code-block:: python
+
+    from web_poet import consume_modules
+
+    consume_modules("my_package.pages", "external_package.pages")
+
+The ideal location for this function depends on your framework. Check the
+documentation of your framework for more information.

--- a/web_poet/rules.py
+++ b/web_poet/rules.py
@@ -74,7 +74,7 @@ class ApplyRule:
     If there are multiple rules which match a certain URL, the rule
     to apply is picked based on the priorities set in ``for_patterns``.
 
-    More information regarding its usage in :ref:`rules-intro`.
+    More information regarding its usage in :ref:`rules`.
 
     .. tip::
 
@@ -118,12 +118,10 @@ class RulesRegistry:
 
         It is encouraged to use the ``web_poet.default_registry`` instead of
         creating your own :class:`~.RulesRegistry` instance. Using multiple
-        registries would be unwieldy in most cases (see :ref:`rules-custom-registry`).
+        registries would be unwieldy in most cases.
 
         However, it might be applicable in certain scenarios like storing custom
-        rules to separate it from the ``default_registry``. This :ref:`example
-        <rules-custom-registry>` from the tutorial section may provide some
-        context.
+        rules to separate it from the ``default_registry``.
     """
 
     def __init__(self, *, rules: Optional[Iterable[ApplyRule]] = None):
@@ -229,16 +227,14 @@ class RulesRegistry:
         more information about them.
 
         This decorator is able to derive the item class returned by the Page
-        Object (see :ref:`rules-item-class-example` section for some examples). This is
-        important since it marks what type of item the Page Object is capable of
-        returning for the given URL patterns. For certain advanced cases, you can
-        pass a ``to_return`` parameter which replaces any derived values (though
-        this isn't generally recommended).
+        Object. This is important since it marks what type of item the Page
+        Object is capable of returning for the given URL patterns. For certain
+        advanced cases, you can pass a ``to_return`` parameter which replaces
+        any derived values (though this isn't generally recommended).
 
         Passing another Page Object into the ``instead_of`` parameter indicates
         that the decorated Page Object will be used instead of that for the given
-        set of URL patterns. This is the concept of **overrides** (see the
-        :ref:`rules-intro-overrides` section for more info`).
+        set of URL patterns. See :ref:`rule-precedence`.
 
         Any extra parameters are stored as meta information that can be later used.
 
@@ -247,7 +243,7 @@ class RulesRegistry:
         :param to_return: The item class holding the data returned by the Page Object.
             This could be omitted as it could be derived from the ``Returns[ItemClass]``
             or ``ItemPage[ItemClass]`` declaration of the Page Object. See
-            :ref:`item-classes` section. Code example in :ref:`rules-combination` subsection.
+            :ref:`item-classes` section.
         :param exclude: The URLs for which the Page Object should **not** be applied.
         :param priority: The resolution priority in case of `conflicting` rules.
             A conflict happens when the ``include``, ``override``, and ``exclude``
@@ -377,10 +373,7 @@ class RulesRegistry:
     ) -> Mapping[Type[ItemPage], Type[ItemPage]]:
         """Finds all of the page objects associated with the given URL and
         returns a Mapping where the 'key' represents the page object that is
-        **overridden** by the page object in 'value'.
-
-        See example: :ref:`rules-overrides_for-example`.
-        """
+        **overridden** by the page object in 'value'."""
         result: Dict[Type[ItemPage], Type[ItemPage]] = {}
         for replaced_page, matcher in self._overrides_matchers.items():
             if replaced_page is None:
@@ -394,10 +387,7 @@ class RulesRegistry:
         self, url: Union[_Url, str], item_cls: Type
     ) -> Optional[Type]:
         """Return the page object class associated with the given URL that's able
-        to produce the given ``item_cls``.
-
-        See example: :ref:`rules-page_cls_for_item-example`.
-        """
+        to produce the given ``item_cls``."""
         if item_cls is None:
             return None
         matcher = self._item_matchers.get(item_cls)


### PR DESCRIPTION
My goal was to greatly simplify https://web-poet.readthedocs.io/en/stable/page-objects/rules.html.

However, I wonder if I went too far; the new pages are ~25% of the old page in terms of line count.

I removed much of the content, and although I aimed to keep the core information around, I did not always do that. For example, the [entire last section](https://web-poet.readthedocs.io/en/stable/page-objects/rules.html#using-rules-from-external-packages) is gone without its information making it in any form into the new page; I wonder if we should keep some of that information.

I recommend reading the old page, then the new pages, and see how you feel about the missing information.