### PR TITLE
BrowserResponse dependency

### DIFF
--- a/docs/page-objects/inputs.rst
+++ b/docs/page-objects/inputs.rst
@@ -59,9 +59,6 @@ define as inputs for a page object class, including:
 -   :class:`~web_poet.page_inputs.page_params.PageParams`, to receive data from
     the crawling code.
 
--   :class:`~web_poet.page_inputs.browser.BrowserHtml`, an HTML rendering of
-    the `Document Object Model`_ of a web page.
-
 -   :class:`~web_poet.page_inputs.browser.BrowserResponse`, which includes URL,
     status code and :class:`~web_poet.page_inputs.browser.BrowserHtml`
     of a rendered web page.

--- a/docs/page-objects/inputs.rst
+++ b/docs/page-objects/inputs.rst
@@ -62,6 +62,10 @@ define as inputs for a page object class, including:
 -   :class:`~web_poet.page_inputs.browser.BrowserHtml`, an HTML rendering of
     the `Document Object Model`_ of a web page.
 
+-   :class:`~web_poet.page_inputs.browser.BrowserResponse`, which includes URL,
+    status code and :class:`~web_poet.page_inputs.browser.BrowserHtml`
+    of a rendered web page.
+
     .. _Document Object Model: https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model
 
 

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -6,7 +6,7 @@ import parsel
 import pytest
 import requests
 
-from web_poet import RequestUrl, ResponseUrl
+from web_poet import BrowserResponse, RequestUrl, ResponseUrl
 from web_poet.page_inputs import (
     BrowserHtml,
     HttpRequest,
@@ -497,6 +497,16 @@ def test_browser_html() -> None:
     assert html.xpath("//p/text()").getall() == ["Hello, ", "world!"]
     assert html.css("p::text").getall() == ["Hello, ", "world!"]
     assert isinstance(html.selector, parsel.Selector)
+
+
+def test_browser_response() -> None:
+    html = "<html><body><p>Hello, </p><p>world!</p></body></html>"
+    response = BrowserResponse(url="http://example.com", html=html, status=200)
+    assert response.xpath("//p/text()").getall() == ["Hello, ", "world!"]
+    assert response.css("p::text").getall() == ["Hello, ", "world!"]
+    assert isinstance(response.selector, parsel.Selector)
+    assert isinstance(response.html, BrowserHtml)
+    assert str(response.urljoin("products")) == "http://example.com/products"
 
 
 @pytest.mark.parametrize(

--- a/web_poet/__init__.py
+++ b/web_poet/__init__.py
@@ -1,6 +1,7 @@
 from .fields import field, item_from_fields, item_from_fields_sync
 from .page_inputs import (
     BrowserHtml,
+    BrowserResponse,
     HttpClient,
     HttpRequest,
     HttpRequestBody,

--- a/web_poet/mixins.py
+++ b/web_poet/mixins.py
@@ -58,9 +58,8 @@ class SelectableMixin(abc.ABC, SelectorShortcutsMixin):
 class UrlShortcutsMixin:
     _cached_base_url = None
 
-    @abc.abstractmethod
     def _url_shortcuts_input(self) -> str:
-        raise NotImplementedError()  # pragma: nocover
+        return self._selector_input()  # type: ignore[attr-defined]
 
     @property
     def _base_url(self) -> str:
@@ -103,9 +102,6 @@ class ResponseShortcutsMixin(SelectableMixin, UrlShortcutsMixin):
         return self.response.text
 
     def _selector_input(self) -> str:
-        return self.html
-
-    def _url_shortcuts_input(self) -> str:
         return self.html
 
     @property

--- a/web_poet/mixins.py
+++ b/web_poet/mixins.py
@@ -1,8 +1,11 @@
 import abc
+from typing import Union
 from urllib.parse import urljoin
 
 import parsel
 from w3lib.html import get_base_url
+
+from web_poet import RequestUrl, ResponseUrl
 
 
 class SelectorShortcutsMixin:
@@ -49,11 +52,33 @@ class SelectableMixin(abc.ABC, SelectorShortcutsMixin):
         return sel
 
 
+class UrlShortcutsMixin:
+    _cached_base_url = None
+
+    @abc.abstractmethod
+    def _url_shortcuts_input(self) -> str:
+        raise NotImplementedError()  # pragma: nocover
+
+    @property
+    def _base_url(self) -> str:
+        if self._cached_base_url is None:
+            text = self._url_shortcuts_input()[:4096]
+            self._cached_base_url = get_base_url(text, str(self.url))
+        return self._cached_base_url
+
+    def urljoin(self, url: Union[str, RequestUrl, ResponseUrl]) -> RequestUrl:
+        """Return *url* as an absolute URL.
+
+        If *url* is relative, it is made absolute relative to the base URL of
+        *self*."""
+        return RequestUrl(urljoin(self._base_url, str(url)))
+
+
 # TODO: when dropping Python 3.7 support,
 # fix untyped ResponseShortcutsMixin.response using typing.Protocol
 
 
-class ResponseShortcutsMixin(SelectableMixin):
+class ResponseShortcutsMixin(SelectableMixin, UrlShortcutsMixin):
     """Common shortcut methods for working with HTML responses.
     This mixin could be used with Page Object base classes.
 
@@ -75,15 +100,10 @@ class ResponseShortcutsMixin(SelectableMixin):
     def _selector_input(self) -> str:
         return self.html
 
-    @property
-    def base_url(self) -> str:
-        """Return the base url of the given response"""
-        if self._cached_base_url is None:
-            text = self.html[:4096]
-            self._cached_base_url = get_base_url(text, self.url)
-        return self._cached_base_url
+    def _url_shortcuts_input(self) -> str:
+        return self.html
 
     def urljoin(self, url: str) -> str:
         """Convert url to absolute, taking in account
         url and baseurl of the response"""
-        return urljoin(self.base_url, url)
+        return str(super().urljoin(url))

--- a/web_poet/mixins.py
+++ b/web_poet/mixins.py
@@ -8,7 +8,7 @@ import parsel
 from w3lib.html import get_base_url
 
 if TYPE_CHECKING:
-    from web_poet.page_inputs.url import RequestUrl, ResponseUrl
+    from web_poet.page_inputs.url import RequestUrl, ResponseUrl  # pragma: nocover
 
 
 class SelectorShortcutsMixin:

--- a/web_poet/mixins.py
+++ b/web_poet/mixins.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 import abc
-from typing import Union
+from typing import TYPE_CHECKING, Union
 from urllib.parse import urljoin
 
 import parsel
 from w3lib.html import get_base_url
 
-from web_poet import RequestUrl, ResponseUrl
+if TYPE_CHECKING:
+    from web_poet.page_inputs.url import RequestUrl, ResponseUrl
 
 
 class SelectorShortcutsMixin:
@@ -63,7 +66,7 @@ class UrlShortcutsMixin:
     def _base_url(self) -> str:
         if self._cached_base_url is None:
             text = self._url_shortcuts_input()[:4096]
-            self._cached_base_url = get_base_url(text, str(self.url))
+            self._cached_base_url = get_base_url(text, str(self.url))  # type: ignore[attr-defined]
         return self._cached_base_url
 
     def urljoin(self, url: Union[str, RequestUrl, ResponseUrl]) -> RequestUrl:
@@ -71,6 +74,8 @@ class UrlShortcutsMixin:
 
         If *url* is relative, it is made absolute relative to the base URL of
         *self*."""
+        from web_poet.page_inputs.url import RequestUrl
+
         return RequestUrl(urljoin(self._base_url, str(url)))
 
 
@@ -103,7 +108,12 @@ class ResponseShortcutsMixin(SelectableMixin, UrlShortcutsMixin):
     def _url_shortcuts_input(self) -> str:
         return self.html
 
-    def urljoin(self, url: str) -> str:
+    @property
+    def base_url(self) -> str:
+        """Return the base url of the given response"""
+        return self._base_url
+
+    def urljoin(self, url: str) -> str:  # type: ignore[override]
         """Convert url to absolute, taking in account
         url and baseurl of the response"""
         return str(super().urljoin(url))

--- a/web_poet/page_inputs/__init__.py
+++ b/web_poet/page_inputs/__init__.py
@@ -1,4 +1,4 @@
-from .browser import BrowserHtml
+from .browser import BrowserHtml, BrowserResponse
 from .client import HttpClient
 from .http import (
     HttpRequest,

--- a/web_poet/page_inputs/browser.py
+++ b/web_poet/page_inputs/browser.py
@@ -1,4 +1,10 @@
-from web_poet.mixins import SelectableMixin
+from typing import Optional
+
+import attrs
+
+from web_poet.mixins import SelectableMixin, UrlShortcutsMixin
+
+from .url import ResponseUrl
 
 
 class BrowserHtml(SelectableMixin, str):
@@ -8,3 +14,27 @@ class BrowserHtml(SelectableMixin, str):
 
     def _selector_input(self) -> str:
         return self
+
+
+@attrs.define(auto_attribs=False, slots=False, eq=False)
+class BrowserResponse(SelectableMixin, UrlShortcutsMixin):
+    """Browser response: url, HTML and status code.
+
+    ``url`` should be browser's window.location, not a URL of the request,
+    if possible.
+
+    ``html`` contains the HTML returned by the browser,
+    i.e. a snapshot of DOM tree in HTML format.
+
+    The following are optional since it would depend on the source of the
+    ``BrowserResponse`` if these are available or not:
+
+    ``status`` should represent the int status code of the HTTP response.
+    """
+
+    url: ResponseUrl = attrs.field(converter=ResponseUrl)
+    html: BrowserHtml = attrs.field(converter=BrowserHtml)
+    status: Optional[int] = attrs.field(default=None, kw_only=True)
+
+    def _selector_input(self) -> str:
+        return self.html

--- a/web_poet/page_inputs/http.py
+++ b/web_poet/page_inputs/http.py
@@ -11,11 +11,10 @@ from w3lib.encoding import (
     read_bom,
     resolve_encoding,
 )
-from w3lib.html import get_base_url
 from w3lib.url import canonicalize_url
 
 from web_poet._base import _HttpHeaders
-from web_poet.mixins import SelectableMixin
+from web_poet.mixins import SelectableMixin, UrlShortcutsMixin
 from web_poet.utils import _create_deprecated_class, memoizemethod_noargs
 
 from .url import RequestUrl as _RequestUrl
@@ -185,7 +184,7 @@ class HttpRequest:
 
 
 @attrs.define(auto_attribs=False, slots=False, eq=False)
-class HttpResponse(SelectableMixin):
+class HttpResponse(SelectableMixin, UrlShortcutsMixin):
     """A container for the contents of a response, downloaded directly using an
     HTTP client.
 
@@ -216,7 +215,6 @@ class HttpResponse(SelectableMixin):
     _encoding: Optional[str] = attrs.field(default=None, kw_only=True)
 
     _DEFAULT_ENCODING = "ascii"
-    _cached_base_url: Optional[str] = None
     _cached_text: Optional[str] = None
 
     @property
@@ -239,6 +237,9 @@ class HttpResponse(SelectableMixin):
     def _selector_input(self) -> str:
         return self.text
 
+    def _url_shortcuts_input(self) -> str:
+        return self.text
+
     @property
     def encoding(self) -> Optional[str]:
         """Encoding of the response"""
@@ -254,20 +255,6 @@ class HttpResponse(SelectableMixin):
     def json(self) -> Any:
         """Deserialize a JSON document to a Python object."""
         return self.body.json()
-
-    @property
-    def _base_url(self) -> str:
-        if self._cached_base_url is None:
-            text = self.text[:4096]
-            self._cached_base_url = get_base_url(text, str(self.url))
-        return self._cached_base_url
-
-    def urljoin(self, url: Union[str, _RequestUrl, _ResponseUrl]) -> _RequestUrl:
-        """Return *url* as an absolute URL.
-
-        If *url* is relative, it is made absolute relative to the base URL of
-        *self*."""
-        return _RequestUrl(urljoin(self._base_url, str(url)))
 
     @memoizemethod_noargs
     def _body_bom_encoding(self) -> Optional[str]:

--- a/web_poet/page_inputs/http.py
+++ b/web_poet/page_inputs/http.py
@@ -237,9 +237,6 @@ class HttpResponse(SelectableMixin, UrlShortcutsMixin):
     def _selector_input(self) -> str:
         return self.text
 
-    def _url_shortcuts_input(self) -> str:
-        return self.text
-
     @property
     def encoding(self) -> Optional[str]:
         """Encoding of the response"""


### PR DESCRIPTION
Here BrowserResponse is added, similar to HttpResponse. The issue with BrowserHtml is that it doesn't allow to access the URL and status code of the response.

I haven't added headers for BrowserResponse for now; it seems we can add them later, as they'd be optional, like in HttpResponse.