### PR TITLE
add new AnyResponse

### DIFF
--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -27,6 +27,12 @@ Page Inputs
    :inherited-members: str,bytes,MultiDict
    :show-inheritance:
 
+.. automodule:: web_poet.page_inputs.response
+   :members:
+   :undoc-members:
+   :inherited-members: str
+   :show-inheritance:
+
 .. automodule:: web_poet.page_inputs.page_params
    :members:
    :undoc-members:

--- a/docs/page-objects/inputs.rst
+++ b/docs/page-objects/inputs.rst
@@ -66,6 +66,11 @@ define as inputs for a page object class, including:
     status code and :class:`~web_poet.page_inputs.browser.BrowserHtml`
     of a rendered web page.
 
+-   :class:`~web_poet.page_inputs.response.AnyResponse`, which either holds
+    :class:`~web_poet.page_inputs.browser.BrowserResponse` or
+    :class:`~web_poet.page_inputs.http.HttpResponse` as the ``.response``
+    instance, depending on which one is available or is more appropriate.
+
     .. _Document Object Model: https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model
 
 

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -649,12 +649,12 @@ def test_http_or_browser_response() -> None:
     url = "http://example.com"
     html = "<html><body><p>Hello, </p><p>world!</p></body></html>"
 
-    browser_response = BrowserResponse(url=url, html=html, status=200)
+    browser_response = BrowserResponse(url=url, html=html)
     response_1 = AnyResponse(response=browser_response)
     assert isinstance(response_1.response, BrowserResponse)
     assert response_1.response == browser_response
 
-    http_response = HttpResponse(url, html.encode())
+    http_response = HttpResponse(url=url, body=html.encode())
     response_2 = AnyResponse(response=http_response)
     assert isinstance(response_2.response, HttpResponse)
     assert response_2.response == http_response
@@ -667,3 +667,10 @@ def test_http_or_browser_response() -> None:
         assert response.css("p::text").getall() == ["Hello, ", "world!"]
         assert isinstance(response.selector, parsel.Selector)
         assert str(response.urljoin("products")) == "http://example.com/products"
+        assert response.status is None
+
+    response = AnyResponse(response=BrowserResponse(url=url, html=html, status=200))
+    assert response.status == 200
+
+    response = AnyResponse(response=HttpResponse(url=url, body=html.encode(), status=200))
+    assert response.status == 200

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -9,6 +9,7 @@ import requests
 from web_poet import BrowserResponse, RequestUrl, ResponseUrl
 from web_poet.page_inputs import (
     BrowserHtml,
+    HttpOrBrowserResponse,
     HttpRequest,
     HttpRequestBody,
     HttpRequestHeaders,
@@ -642,3 +643,26 @@ def test_stats() -> None:
     stats.inc("c")
 
     assert stats._stats._stats == {"a": "1", "b": 8, "c": 1}
+
+
+def test_http_or_browser_response() -> None:
+    url = "http://example.com"
+    html = "<html><body><p>Hello, </p><p>world!</p></body></html>"
+
+    browser_response = BrowserResponse(url=url, html=html, status=200)
+    response_1 = HttpOrBrowserResponse(response=browser_response)
+
+    assert isinstance(response_1.response, BrowserResponse)
+    assert response_1.response == browser_response
+    assert isinstance(response_1.url, ResponseUrl)
+    assert str(response_1.url) == url
+    assert response_1.text == html
+
+    http_response = HttpResponse(url, html.encode())
+    response_2 = HttpOrBrowserResponse(response=http_response)
+
+    assert isinstance(response_2.response, HttpResponse)
+    assert response_2.response == http_response
+    assert isinstance(response_2.url, ResponseUrl)
+    assert str(response_2.url) == url
+    assert response_2.text == html

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -672,5 +672,7 @@ def test_http_or_browser_response() -> None:
     response = AnyResponse(response=BrowserResponse(url=url, html=html, status=200))
     assert response.status == 200
 
-    response = AnyResponse(response=HttpResponse(url=url, body=html.encode(), status=200))
+    response = AnyResponse(
+        response=HttpResponse(url=url, body=html.encode(), status=200)
+    )
     assert response.status == 200

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -651,18 +651,19 @@ def test_http_or_browser_response() -> None:
 
     browser_response = BrowserResponse(url=url, html=html, status=200)
     response_1 = AnyResponse(response=browser_response)
-
     assert isinstance(response_1.response, BrowserResponse)
     assert response_1.response == browser_response
-    assert isinstance(response_1.url, ResponseUrl)
-    assert str(response_1.url) == url
-    assert response_1.text == html
 
     http_response = HttpResponse(url, html.encode())
     response_2 = AnyResponse(response=http_response)
-
     assert isinstance(response_2.response, HttpResponse)
     assert response_2.response == http_response
-    assert isinstance(response_2.url, ResponseUrl)
-    assert str(response_2.url) == url
-    assert response_2.text == html
+
+    for response in [response_1, response_2]:
+        assert isinstance(response.url, ResponseUrl)
+        assert str(response.url) == url
+        assert response.text == html
+        assert response.xpath("//p/text()").getall() == ["Hello, ", "world!"]
+        assert response.css("p::text").getall() == ["Hello, ", "world!"]
+        assert isinstance(response.selector, parsel.Selector)
+        assert str(response.urljoin("products")) == "http://example.com/products"

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -8,8 +8,8 @@ import requests
 
 from web_poet import BrowserResponse, RequestUrl, ResponseUrl
 from web_poet.page_inputs import (
+    AnyResponse,
     BrowserHtml,
-    HttpOrBrowserResponse,
     HttpRequest,
     HttpRequestBody,
     HttpRequestHeaders,
@@ -650,7 +650,7 @@ def test_http_or_browser_response() -> None:
     html = "<html><body><p>Hello, </p><p>world!</p></body></html>"
 
     browser_response = BrowserResponse(url=url, html=html, status=200)
-    response_1 = HttpOrBrowserResponse(response=browser_response)
+    response_1 = AnyResponse(response=browser_response)
 
     assert isinstance(response_1.response, BrowserResponse)
     assert response_1.response == browser_response
@@ -659,7 +659,7 @@ def test_http_or_browser_response() -> None:
     assert response_1.text == html
 
     http_response = HttpResponse(url, html.encode())
-    response_2 = HttpOrBrowserResponse(response=http_response)
+    response_2 = AnyResponse(response=http_response)
 
     assert isinstance(response_2.response, HttpResponse)
     assert response_2.response == http_response

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -162,7 +162,7 @@ def test_apply_rule_kwargs_only() -> None:
             ApplyRule(
                 "example.com",
                 *[params[r] for r in remove],
-                **{k: v for k, v in params.items() if k not in remove},  # type: ignore[arg-type]
+                **{k: v for k, v in params.items() if k not in remove},  # type: ignore[arg-type]  # noqa: B038
             )
 
 

--- a/web_poet/__init__.py
+++ b/web_poet/__init__.py
@@ -1,9 +1,9 @@
 from .fields import field, item_from_fields, item_from_fields_sync
 from .page_inputs import (
+    AnyResponse,
     BrowserHtml,
     BrowserResponse,
     HttpClient,
-    HttpOrBrowserResponse,
     HttpRequest,
     HttpRequestBody,
     HttpRequestHeaders,

--- a/web_poet/__init__.py
+++ b/web_poet/__init__.py
@@ -3,6 +3,7 @@ from .page_inputs import (
     BrowserHtml,
     BrowserResponse,
     HttpClient,
+    HttpOrBrowserResponse,
     HttpRequest,
     HttpRequestBody,
     HttpRequestHeaders,

--- a/web_poet/page_inputs/__init__.py
+++ b/web_poet/page_inputs/__init__.py
@@ -9,6 +9,6 @@ from .http import (
     HttpResponseHeaders,
 )
 from .page_params import PageParams
-from .response import HttpOrBrowserResponse
+from .response import AnyResponse
 from .stats import Stats
 from .url import RequestUrl, ResponseUrl

--- a/web_poet/page_inputs/__init__.py
+++ b/web_poet/page_inputs/__init__.py
@@ -9,5 +9,6 @@ from .http import (
     HttpResponseHeaders,
 )
 from .page_params import PageParams
+from .response import HttpOrBrowserResponse
 from .stats import Stats
 from .url import RequestUrl, ResponseUrl

--- a/web_poet/page_inputs/response.py
+++ b/web_poet/page_inputs/response.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Union
 
 import attrs
 
@@ -25,6 +25,13 @@ class AnyResponse(SelectableMixin, UrlShortcutsMixin):
         if isinstance(self.response, BrowserResponse):
             return self.response.html
         return self.response.text
+
+    @property
+    def status(self) -> Optional[int]:
+        """The int status code of the HTTP response, if available."""
+        if getattr(self.response, "status", None):
+            return self.response.status
+        return None
 
     def _selector_input(self) -> str:
         return self.text

--- a/web_poet/page_inputs/response.py
+++ b/web_poet/page_inputs/response.py
@@ -2,13 +2,14 @@ from typing import Union
 
 import attrs
 
+from web_poet.mixins import SelectableMixin, UrlShortcutsMixin
 from web_poet.page_inputs.browser import BrowserResponse
 from web_poet.page_inputs.http import HttpResponse
 from web_poet.page_inputs.url import ResponseUrl
 
 
 @attrs.define
-class AnyResponse:
+class AnyResponse(SelectableMixin, UrlShortcutsMixin):
     """A container that holds either :class:`~.BrowserResponse` or :class:`~.HttpResponse.`"""
 
     response: Union[BrowserResponse, HttpResponse]
@@ -24,3 +25,6 @@ class AnyResponse:
         if isinstance(self.response, BrowserResponse):
             return self.response.html
         return self.response.text
+
+    def _selector_input(self) -> str:
+        return self.text

--- a/web_poet/page_inputs/response.py
+++ b/web_poet/page_inputs/response.py
@@ -1,0 +1,26 @@
+from typing import Union
+
+import attrs
+
+from web_poet.page_inputs.browser import BrowserResponse
+from web_poet.page_inputs.http import HttpResponse
+from web_poet.page_inputs.url import ResponseUrl
+
+
+@attrs.define
+class HttpOrBrowserResponse:
+    """A container that holds either :class:`~.BrowserResponse` or :class:`~.HttpResponse.`"""
+
+    response: Union[BrowserResponse, HttpResponse]
+
+    @property
+    def url(self) -> ResponseUrl:
+        """URL of the response."""
+        return self.response.url
+
+    @property
+    def text(self) -> str:
+        """Contents of the response."""
+        if isinstance(self.response, BrowserResponse):
+            return self.response.html
+        return self.response.text

--- a/web_poet/page_inputs/response.py
+++ b/web_poet/page_inputs/response.py
@@ -10,7 +10,7 @@ from web_poet.page_inputs.url import ResponseUrl
 
 @attrs.define
 class AnyResponse(SelectableMixin, UrlShortcutsMixin):
-    """A container that holds either :class:`~.BrowserResponse` or :class:`~.HttpResponse.`"""
+    """A container that holds either :class:`~.BrowserResponse` or :class:`~.HttpResponse`."""
 
     response: Union[BrowserResponse, HttpResponse]
 
@@ -21,7 +21,7 @@ class AnyResponse(SelectableMixin, UrlShortcutsMixin):
 
     @property
     def text(self) -> str:
-        """Contents of the response."""
+        """Text or HTML contents of the response."""
         if isinstance(self.response, BrowserResponse):
             return self.response.html
         return self.response.text

--- a/web_poet/page_inputs/response.py
+++ b/web_poet/page_inputs/response.py
@@ -8,7 +8,7 @@ from web_poet.page_inputs.url import ResponseUrl
 
 
 @attrs.define
-class HttpOrBrowserResponse:
+class AnyResponse:
     """A container that holds either :class:`~.BrowserResponse` or :class:`~.HttpResponse.`"""
 
     response: Union[BrowserResponse, HttpResponse]

--- a/web_poet/page_inputs/response.py
+++ b/web_poet/page_inputs/response.py
@@ -29,9 +29,7 @@ class AnyResponse(SelectableMixin, UrlShortcutsMixin):
     @property
     def status(self) -> Optional[int]:
         """The int status code of the HTTP response, if available."""
-        if getattr(self.response, "status", None):
-            return self.response.status
-        return None
+        return self.response.status
 
     def _selector_input(self) -> str:
         return self.text


### PR DESCRIPTION
A way to address https://github.com/zytedata/zyte-spider-templates/issues/25.

Related PRs:
- https://github.com/scrapinghub/scrapy-poet/pull/184
- https://github.com/scrapy-plugins/scrapy-zyte-api/pull/161
- https://github.com/zytedata/zyte-spider-templates/pull/28

~Not quite sure if we should have a detailed documentation about this class in the tutorials since it may be deprecated in the next few months when Zyte API handles Auto-Configuration (_i.e. selecting the best extraction source between HttpResponse and BrowserResponse_).~ **EDIT:** Added docs.