### PR TITLE
Add base_url to Selector and implement HttpRequest.from_form

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+exclude_lines =
+    if TYPE_CHECKING:

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -291,6 +291,26 @@ def test_http_request_from_form_select_no_selected() -> None:
     assert request.body == b"query=&bar=code&baz=ooka"
 
 
+def test_http_request_from_form_select_no_options() -> None:
+    url = "https://example.com"
+    response = HttpResponse(
+        url,
+        b"""
+        <!doctype html>
+        <title>a</title>
+        <form id="search-form" accept-charset="utf-8" action="/search" method="POST">
+            <input type="text" value="" name="query">
+            <select name="bar"></select>
+            <input type="submit">
+            <input type="hidden" name="baz" value="ooka">
+        </form>
+        """,
+    )
+    form_selector = response.css("#search-form")[0]
+    request = HttpRequest.from_form(form_selector.root)
+    assert request.body == b"query=&baz=ooka"
+
+
 def test_http_request_from_form_no_method() -> None:
     url = "https://example.com"
     response = HttpResponse(

--- a/web_poet/mixins.py
+++ b/web_poet/mixins.py
@@ -46,12 +46,12 @@ class SelectableMixin(abc.ABC, SelectorShortcutsMixin):
     @property
     def selector(self) -> parsel.Selector:
         """Cached instance of :external:class:`parsel.selector.Selector`."""
-        # XXX: caching is implemented in a manual way to avoid issues with
+        # caching is implemented in a manual way to avoid issues with
         # non-hashable classes, where memoizemethod_noargs doesn't work
         if self.__cached_selector is not None:
             return self.__cached_selector
-        # XXX: should we pass base_url=self.url, as Scrapy does?
-        sel = parsel.Selector(text=self._selector_input())
+        base_url = str(self.url) if hasattr(self, "url") else None
+        sel = parsel.Selector(text=self._selector_input(), base_url=base_url)
         self.__cached_selector = sel
         return sel
 

--- a/web_poet/page_inputs/http.py
+++ b/web_poet/page_inputs/http.py
@@ -254,7 +254,7 @@ class HttpRequest:
             assert method == "POST"
             headers = {"Content-Type": "application/x-www-form-urlencoded"}
             body = query.encode()
-        return HttpRequest(
+        return cls(
             url=url,
             method=method,
             headers=headers,

--- a/web_poet/page_inputs/http.py
+++ b/web_poet/page_inputs/http.py
@@ -154,23 +154,21 @@ def _is_listlike(x: Any) -> bool:
 
 
 def _value(
-    form: Union[InputElement, SelectElement, TextareaElement]
+    element: Union[InputElement, SelectElement, TextareaElement]
 ) -> Tuple[Optional[str], Union[None, str, MultipleSelectOptions]]:
-    if form.tag == "select":
-        return _select_value(cast(SelectElement, form), form.name, form.value)
-    return form.name, form.value
+    if element.tag == "select":
+        return _select_value(cast(SelectElement, element), element.name, element.value)
+    return element.name, element.value
 
 
 def _select_value(
-    form: SelectElement,
+    element: SelectElement,
     name: Optional[str],
     value: Union[None, str, MultipleSelectOptions],
 ) -> Tuple[Optional[str], Union[None, str, MultipleSelectOptions]]:
-    if value is None and not form.multiple:
-        # Match browser behavior on simple select tag without options selected
-        # And for select tags without options
-        options = form.value_options
-        return (name, options[0]) if options else (None, None)
+    if value is None and not element.multiple:
+        # Match browser behavior on select tags without options
+        return (None, None)
     return name, value
 
 

--- a/web_poet/page_inputs/http.py
+++ b/web_poet/page_inputs/http.py
@@ -175,10 +175,7 @@ def _select_value(
 
 
 def _get_form_query(form: FormElement, data: FormdataType) -> str:
-    try:
-        keys = dict(data or ()).keys()
-    except (ValueError, TypeError):
-        raise ValueError("data should be a dict or iterable of tuples")
+    keys = dict(data or ()).keys()
     if not data:
         data = []
     inputs = form.xpath(
@@ -207,8 +204,7 @@ def _get_form_query(form: FormElement, data: FormdataType) -> str:
 
 def _get_form_method(form: FormElement) -> str:
     method = form.method
-    if method is None:
-        raise ValueError(f"{form} has no method set.")
+    assert method is not None
     method = method.upper()
     if method not in {"GET", "POST"}:
         method = "GET"
@@ -240,7 +236,7 @@ class HttpRequest:
     )
 
     @classmethod
-    def from_form(cls, form: FormElement, data: FormdataType) -> Self:
+    def from_form(cls, form: FormElement, data: FormdataType = None) -> Self:
         """Return an :class:`HttpRequest` to submit *form* with the
         specified *data*."""
         query = _get_form_query(form, data)


### PR DESCRIPTION
`HttpRequest.from_form` is based on [Scrapy’s FormRequest.from_response()](https://github.com/scrapy/scrapy/blob/1282ddf8f77299edf613679c2ee0b606e96808ce/scrapy/http/request/form.py#L69), but with a minimal API and without support for the `click` thing which I don’t fully understand.