### PR TITLE
Do not consider type(None) injectable

### DIFF
--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -69,6 +69,7 @@ def test_is_injectable() -> None:
             }
 
     assert is_injectable(None) is False
+    assert is_injectable(type(None)) is False
     assert is_injectable(MyClass) is False
     assert is_injectable(MyClass()) is False
     assert is_injectable(MyItemPage) is True

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -35,10 +35,6 @@ class Injectable(abc.ABC, FieldsMixin):
     pass
 
 
-# NoneType is considered as injectable. Required for Optionals to work.
-Injectable.register(type(None))
-
-
 def is_injectable(cls: Any) -> bool:
     """Return True if ``cls`` is a class which inherits
     from :class:`~.Injectable`."""


### PR DESCRIPTION
I am hoping the comment is out of date or wrong, but I am not 100% sure of what the line was meant to fix. @kmike Do you recall why this line was there? (it comes from the initial commit).

This change does break 2 scrapy-poet tests, but I believe those tests expectations are what’s wrong (https://github.com/scrapinghub/scrapy-poet/pull/218).

cc @kalessin