### PR TITLE
Fix is_injectable() error with GenericAlias on Python < 3.11.

### DIFF
--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -68,8 +68,16 @@ def test_is_injectable() -> None:
                 "foo": "bar",
             }
 
+    from collections.abc import Set as CollectionsSet
+    from typing import Set as TypingSet
+
     assert is_injectable(None) is False
     assert is_injectable(type(None)) is False
+    assert is_injectable(set) is False
+    assert is_injectable(set[str]) is False
+    assert is_injectable(TypingSet[str]) is False
+    assert is_injectable(CollectionsSet[str]) is False
+    assert is_injectable(Optional[str]) is False
     assert is_injectable(MyClass) is False
     assert is_injectable(MyClass()) is False
     assert is_injectable(MyItemPage) is True

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -40,8 +40,8 @@ def is_injectable(cls: Any) -> bool:
     """Return True if ``cls`` is a class which inherits
     from :class:`~.Injectable`."""
     return (
-        not isinstance(cls, GenericAlias)
-        and isinstance(cls, type)
+        isinstance(cls, type)
+        and not isinstance(cls, GenericAlias)
         and issubclass(cls, Injectable)
     )
 

--- a/web_poet/pages.py
+++ b/web_poet/pages.py
@@ -2,6 +2,7 @@ import abc
 import inspect
 from contextlib import suppress
 from functools import wraps
+from types import GenericAlias
 from typing import Any, Generic, Optional, TypeVar, overload
 
 import attr
@@ -38,7 +39,11 @@ class Injectable(abc.ABC, FieldsMixin):
 def is_injectable(cls: Any) -> bool:
     """Return True if ``cls`` is a class which inherits
     from :class:`~.Injectable`."""
-    return isinstance(cls, type) and issubclass(cls, Injectable)
+    return (
+        not isinstance(cls, GenericAlias)
+        and isinstance(cls, type)
+        and issubclass(cls, Injectable)
+    )
 
 
 ItemT = TypeVar("ItemT")


### PR DESCRIPTION
`isinstance(cls, type)` is True for `typing.GenericAlias` types, such as `list[...]` on Python 3.9 and 3.10 (see https://bugs.python.org/issue45665), but `issubclass()` produces "TypeError: issubclass() arg 1 must be a class" on such classes.