### PR TITLE
Fix CI issues, bump CI Python versions.

### DIFF
--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12']  # keep in sync with .readthedocs.yml
+        python-version: ['3.13']  # keep in sync with .readthedocs.yml
         tox-job: ["mypy", "docs", "linters", "types", "twinecheck"]
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/_build
 *.egg-info/
 __pycache__/
 build/
+.idea/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,9 +4,9 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.12"  # Keep in sync with .github/workflows/tests-ubuntu.yml
+    python: "3.13"  # Keep in sync with .github/workflows/tests-ubuntu.yml
 
 python:
   install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,7 @@ exclude_also = [
 ]
 
 [tool.mypy]
-ignore_missing_imports = true
-no_warn_no_return = true
+warn_no_return = false
 
 [[tool.mypy.overrides]]
 module = "tests.po_lib_to_return.*"

--- a/tests/po_lib/__init__.py
+++ b/tests/po_lib/__init__.py
@@ -16,7 +16,7 @@ from .. import po_lib_sub  # noqa: F401
 
 class POBase(ItemPage):
     expected_instead_of: type[ItemPage] | list[type[ItemPage]]
-    expected_patterns: Patterns
+    expected_patterns: Patterns | list[Patterns]
     expected_to_return: Any = None
     expected_meta: dict[str, Any]
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -132,11 +132,8 @@ def test_apply_rule_immutability() -> None:
 def test_apply_rule_converter_on_pattern() -> None:
     # passing strings should auto-converter into Patterns
     rule = ApplyRule("example.com", use=POTopLevel1, instead_of=POTopLevelOverriden2)
-    # too strict type hints in url-matcher 0.6.0
     assert rule.for_patterns == Patterns(
-        include=("example.com",),  # type: ignore[arg-type]
-        exclude=(),  # type: ignore[arg-type]
-        priority=500,
+        include=["example.com"], exclude=[], priority=500
     )
 
     # Passing Patterns should still work
@@ -145,11 +142,8 @@ def test_apply_rule_converter_on_pattern() -> None:
         use=POTopLevel1,
         instead_of=POTopLevelOverriden2,
     )
-    # too strict type hints in url-matcher 0.6.0
     assert rule.for_patterns == Patterns(
-        include=("example.com",),  # type: ignore[arg-type]
-        exclude=(),  # type: ignore[arg-type]
-        priority=500,
+        include=["example.com"], exclude=[], priority=500
     )
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -103,10 +103,10 @@ def test_apply_rule_uniqueness() -> None:
 
     for change in params[0]:
         # Changing any one of the params should result in a hash mismatch
-        rule1 = ApplyRule(**params[0])
+        rule1 = ApplyRule(**params[0])  # type: ignore[arg-type]
         kwargs = params[0].copy()
         kwargs.update({change: params[1][change]})
-        rule2 = ApplyRule(**kwargs)
+        rule2 = ApplyRule(**kwargs)  # type: ignore[arg-type]
         assert hash(rule1) != hash(rule2)
 
 
@@ -132,8 +132,11 @@ def test_apply_rule_immutability() -> None:
 def test_apply_rule_converter_on_pattern() -> None:
     # passing strings should auto-converter into Patterns
     rule = ApplyRule("example.com", use=POTopLevel1, instead_of=POTopLevelOverriden2)
+    # too strict type hints in url-matcher 0.6.0
     assert rule.for_patterns == Patterns(
-        include=("example.com",), exclude=(), priority=500
+        include=("example.com",),  # type: ignore[arg-type]
+        exclude=(),  # type: ignore[arg-type]
+        priority=500,
     )
 
     # Passing Patterns should still work
@@ -142,8 +145,11 @@ def test_apply_rule_converter_on_pattern() -> None:
         use=POTopLevel1,
         instead_of=POTopLevelOverriden2,
     )
+    # too strict type hints in url-matcher 0.6.0
     assert rule.for_patterns == Patterns(
-        include=("example.com",), exclude=(), priority=500
+        include=("example.com",),  # type: ignore[arg-type]
+        exclude=(),  # type: ignore[arg-type]
+        priority=500,
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,12 +29,13 @@ commands =
 [testenv:mypy]
 deps =
     mypy==1.11.2
-    aiohttp
-    py
-    pytest
-    types-requests
-    types-python-dateutil
-    zyte-common-items
+    aiohttp==3.11.18
+    py==1.11.0
+    pytest==8.3.5
+    types-requests==2.32.0.20250515
+    types-python-dateutil==2.9.0.20250516
+    url-matcher==0.6.0
+    zyte-common-items==0.27.0
 
 commands = mypy web_poet tests
 
@@ -79,13 +80,14 @@ deps =
     python-dateutil==2.7.0
     time-machine==2.7.1
     packaging==20.0
-
+    # pin older cssselect for old parsel
+    cssselect==1.2.0
 
 [testenv:twinecheck]
 basepython = python3
 deps =
-    twine==5.1.1
-    build==1.2.2
+    twine==6.1.0
+    build==1.2.2.post1
 commands =
     python -m build --sdist
     twine check dist/*

--- a/web_poet/rules.py
+++ b/web_poet/rules.py
@@ -402,7 +402,7 @@ class RulesRegistry:
         if not matcher:
             return
         max_priority = None
-        for rule_id in matcher.match_all(url):
+        for rule_id in matcher.match_all(str(url)):
             rule = self._rules[rule_id]
             if max_priority is None:
                 max_priority = rule.for_patterns.priority


### PR DESCRIPTION
Fix type checks for typed url-matcher, pin cssselect in the pinned env, switch to Python 3.13 for CI, pin package versions in the mypy check.