### PR TITLE
Support serialization of output items with RequestUrl objects

### DIFF
--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -10,6 +10,7 @@ from web_poet import (
     Injectable,
     ItemPage,
     PageParams,
+    RequestUrl,
     ResponseUrl,
     Stats,
     WebPage,
@@ -77,16 +78,20 @@ def test_serialization(book_list_html_response) -> None:
     class MyWebPage(ItemPage):
         response: HttpResponse
         url: ResponseUrl
+        request_url: RequestUrl
         params: PageParams
         data: ResponseData
         stats: Stats
 
     url_str = "http://books.toscrape.com/index.html"
     url = ResponseUrl(url_str)
+    request_url = RequestUrl(url_str)
     page_params = PageParams(foo="bar")
     stats = Stats()
 
-    serialized_deps = serialize([book_list_html_response, url, page_params, stats])
+    serialized_deps = serialize(
+        [book_list_html_response, url, request_url, page_params, stats]
+    )
     info_json = f"""{{
   "_encoding": "utf-8",
   "headers": [],
@@ -101,6 +106,9 @@ def test_serialization(book_list_html_response) -> None:
         "ResponseUrl": {
             "txt": url_str.encode(),
         },
+        "RequestUrl": {
+            "txt": url_str.encode(),
+        },
         "PageParams": {
             "json": b'{\n  "foo": "bar"\n}',
         },
@@ -110,6 +118,7 @@ def test_serialization(book_list_html_response) -> None:
     po = MyWebPage(
         book_list_html_response,
         url,
+        request_url,
         page_params,
         ResponseData(book_list_html_response),
         Stats(),

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -610,3 +610,14 @@ def test_request_url_output_serialization(book_list_html_response, tmp_path) -> 
 
     Fixture.save(base_dir, inputs=[book_list_html_response], item=item)
     _assert_fixture_files(base_dir / "test-1")
+
+
+def test_unserializable(book_list_html_response, tmp_path) -> None:
+    class Foo:
+        pass
+
+    base_dir = tmp_path / "fixtures" / "some.po"
+    item = {"foo": Foo()}
+
+    with pytest.raises(TypeError):
+        Fixture.save(base_dir, inputs=[book_list_html_response], item=item)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -207,6 +207,22 @@ def test_pytest_plugin_compare_item(pytester, book_list_html_response) -> None:
     result.assert_outcomes(passed=1)
 
 
+def test_pytest_plugin_compare_item_unformatted_output(
+    pytester, book_list_html_response
+) -> None:
+    _save_fixture(
+        pytester,
+        page_cls=MyItemPage,
+        page_inputs=[book_list_html_response],
+        expected_output={"foo": "bar"},
+    )
+    base_dir = pytester.path / "fixtures" / get_fq_class_name(MyItemPage)
+    fixture = Fixture(base_dir / "test-1")
+    fixture.output_path.write_text('{"foo":"bar"}')
+    result = pytester.runpytest("--web-poet-test-per-item")
+    result.assert_outcomes(passed=1)
+
+
 def test_pytest_plugin_compare_item_fail(pytester, book_list_html_response) -> None:
     _save_fixture(
         pytester,

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -214,11 +214,19 @@ def test_pytest_plugin_compare_item_fail(pytester, book_list_html_response) -> N
         page_inputs=[book_list_html_response],
         expected_output={"foo": "not bar"},
     )
-    result = pytester.runpytest("--web-poet-test-per-item")
+    result = pytester.runpytest("--web-poet-test-per-item", "-vv")
     result.assert_outcomes(passed=0, failed=1)
 
-    result.stdout.fnmatch_lines("*{'foo': 'bar'} != {'foo': 'not bar'}*")
-    result.stdout.fnmatch_lines("*The output doesn't match*")
+    result.stdout.fnmatch_lines(
+        "*The output doesn't match.\n"
+        '\'{\\n  "foo": "bar"\\n}\' == \'{\\n  "foo": "not bar"\\n}\'\n'
+        "\n"
+        "  {\n"
+        '-   "foo": "not bar"\n'
+        "?           ----\n"
+        '+   "foo": "bar"\n'
+        "  }*"
+    )
 
 
 @attrs.define(kw_only=True)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -220,7 +220,7 @@ def test_pytest_plugin_compare_item_fail(pytester, book_list_html_response) -> N
     result.stdout.fnmatch_lines(
         "*The output doesn't match.\n"
         '\'{\\n  "foo": "bar"\\n}\' == \'{\\n  "foo": "not bar"\\n}\'\n'
-        "\n"
+        "*"
         "  {\n"
         '-   "foo": "not bar"\n'
         "?           ----\n"

--- a/web_poet/serialization/utils.py
+++ b/web_poet/serialization/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from web_poet.page_inputs.url import _Url
 from web_poet.serialization.api import _get_name_for_class, load_class
 
 
@@ -28,4 +29,13 @@ def _exception_from_dict(data: dict[str, Any]) -> Exception:
 
 def _format_json(data: Any) -> str:
     """Produce a formatted JSON string with preset options."""
-    return json.dumps(data, ensure_ascii=False, sort_keys=True, indent=2)
+    return json.dumps(
+        data, ensure_ascii=False, sort_keys=True, indent=2, cls=_CustomJSONEncoder
+    )
+
+
+class _CustomJSONEncoder(json.JSONEncoder):
+    def default(self, o: Any) -> Any:
+        if isinstance(o, _Url):
+            return str(o)
+        return super().default(o)

--- a/web_poet/testing/fixture.py
+++ b/web_poet/testing/fixture.py
@@ -158,14 +158,9 @@ class Fixture:
         return _format_json(self._get_adapter_cls()(item).asdict())
 
     @memoizemethod_noargs
-    def get_expected_output_bytes(self) -> bytes:
-        """Return the saved output as bytes."""
-        return self.output_path.read_bytes()
-
-    @memoizemethod_noargs
     def get_expected_output(self) -> dict:
         """Return the saved output."""
-        return json.loads(self.get_expected_output_bytes())
+        return json.loads(self.output_path.read_bytes())
 
     @memoizemethod_noargs
     def get_expected_exception(self) -> Exception:
@@ -207,7 +202,7 @@ class Fixture:
     def assert_full_item_correct(self):
         """Get the output and assert that it matches the expected output."""
         output = _format_json(self.get_output())
-        expected_output = self.get_expected_output_bytes()
+        expected_output = self.output_path.read_text()
         if output != expected_output:
             raise ItemValueIncorrect(output, expected_output)
 
@@ -216,8 +211,8 @@ class Fixture:
         actual_item = self.get_output()
         if name not in actual_item:
             raise FieldMissing(name)
-        expected_field = _format_json(self.get_expected_output()[name])
-        actual_field = _format_json(actual_item[name])
+        expected_field = json.loads(_format_json(self.get_expected_output()[name]))
+        actual_field = json.loads(_format_json(actual_item[name]))
         if actual_field != expected_field:
             raise FieldValueIncorrect(actual_field, expected_field)
 

--- a/web_poet/testing/fixture.py
+++ b/web_poet/testing/fixture.py
@@ -202,7 +202,7 @@ class Fixture:
     def assert_full_item_correct(self):
         """Get the output and assert that it matches the expected output."""
         output = _format_json(self.get_output())
-        expected_output = self.output_path.read_text()
+        expected_output = _format_json(self.get_expected_output())
         if output != expected_output:
             raise ItemValueIncorrect(output, expected_output)
 


### PR DESCRIPTION
At first I thought the issue affected serialization of `RequestUrl` inputs, and extended tests for that. When that passed, I realized the issue was in output item serialization, but I kept the previous test extension, for better coverage.