### PR TITLE
Allow running individual tests

### DIFF
--- a/web_poet/testing/pytest.py
+++ b/web_poet/testing/pytest.py
@@ -264,11 +264,10 @@ def collect_file_hook(
         if not fixture.is_valid():
             return None
         fixtures_test_file = page_dir.parent / "test.py"
-        if (
-            fixtures_test_file in _found_fixtures_test_files
-            or not fixtures_test_file.exists()
-        ):
+        if fixtures_test_file in _found_fixtures_test_files:
             return None
+        if not fixtures_test_file.exists():
+            fixtures_test_file.write_text("")
         _found_fixtures_test_files.add(fixtures_test_file)
         return _get_file(parent, path=fixtures_test_file)
     if file_path.name == "test.py" and file_path not in _found_fixtures_test_files:


### PR DESCRIPTION
Resolves #144.

This is a backward-incompatible PR that I am completely OK with closing without merging.

# Implementation

It makes it so that the node IDs of tests use non-filesystem sections for all components (page object import path, test case ID, field test or special item test) instead of using a path for those first 2.

To achieve that, it requires a `test.py` file (its contents are ignored, the filename was an arbitrary choice) at the root of `fixtures/`. While ideally `scrapy savefixture` should create that file, the proposed implementation hackily creates it when you run `pytest` on its own or `pytest fixtures/`, for usability purposes.

The result is that an old node ID like:

> `fixtures/books_scraper.pages.news_ycombinator_com.HackerNewsHomePage/test-1::next_page_url`

Now becomes:

> `fixtures/test.py::books_scraper.pages.news_ycombinator_com.HackerNewsHomePage::test-1::next_page_url`

# The good

Unlike before, that complete node ID for a single test can be run:

```
$ pytest fixtures/test.py::books_scraper.pages.news_ycombinator_com.HackerNewsHomePage::test-1::next_page_url
===================================================== test session starts =====================================================
platform linux -- Python 3.13.3, pytest-8.4.0, pluggy-1.6.0
rootdir: /home/adrian/temporal/project
configfile: pytest.ini
plugins: time-machine-2.16.0, web-poet-0.18.0
collected 1 item                                                                                                              

fixtures/test.py .                                                                                                      [100%]

====================================================== 1 passed in 0.05s ======================================================
```

# The bad

This is of course backward-incompatible when it comes to running tests. `pytest` and `pytest fixtures/` work as before, but everything else has a different node ID now, so you need to change the command to run subsets of tests.

Also, a significant tradeoff of supporting running a single test is that you can no longer take advantage of terminal autocompletion to build the command to run all tests for a given page object class or for one of its test cases.

# The ugly

My main goal that lead me to this PR was not to address #144, but to address #188. But I was not able to achieve that in a reasonable time, and I am not sure if it is worth pursuing at this point.

The main issue seems to be that the [build_test_tree](https://github.com/microsoft/vscode-python/blob/02476f0ac9873be3aed81d39b62d367c6947e389/python_files/vscode_pytest/__init__.py#L526) function of vscode-python makes some assumptions regarding pytest node IDs, with `::`-based splits and similar. That may be what’s causing other issues reported upstream like https://github.com/microsoft/vscode-python/issues/24455, https://github.com/microsoft/vscode-python/issues/23868, but not sure.

Making our test collection work might require something bold like (in no particular order):
- Rewrite our fixture test to be more like regular pytest tests. I think having a file inside each testcase folder might be get us a long wait, possibly address things and not require the root `test.py` (maybe I’ll test this)
- Make upstream changes to that function to work with custom test collections like ours. Not sure how feasible it is to do, though; you have to assume that the complexity of the current implementation is that way for a reason.
- Write our own pytest integration, at least for fixtures. Not ideal in the least, in my opinion.

