### PR TITLE
Add support for pytest 9.1.0 to comparison_error_message().

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     mypy==1.16.1
     aiohttp==3.12.13
     andi==0.8.0
-    pytest==8.4.1
+    pytest==9.1.0
     types-requests==2.32.4.20250611
     types-python-dateutil==2.9.0.20250516
     url-matcher==0.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ extras = framework
 deps =
     {[testenv]deps}
     {[testenv:mypy]deps}
-    pytest-mypy-testing==0.1.3
+    pytest-mypy-testing==0.2.0
 
 commands = py.test {posargs: tests_typing}
 

--- a/web_poet/testing/utils.py
+++ b/web_poet/testing/utils.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from _pytest.assertion.util import assertrepr_compare
-
-if TYPE_CHECKING:
-    import pytest
+import _pytest.assertion.util as assertion_util
+import pytest
 
 
 def comparison_error_message(
@@ -14,9 +12,24 @@ def comparison_error_message(
     """Generate an error message"""
     lines = [prefix] if prefix else []
 
-    explanation_lines = assertrepr_compare(
-        config=config, op=op, left=got, right=expected
-    )
+    # assertrepr_compare() signature was changed in 9.1.0 in PRs 14418, 14425 and 14546
+    if pytest.version_tuple >= (9, 1, 0):
+        explanation_lines = list(
+            assertion_util.assertrepr_compare(
+                op=op,
+                left=got,
+                right=expected,
+                verbose=config.get_verbosity(pytest.Config.VERBOSITY_ASSERTIONS),
+                highlighter=assertion_util.dummy_highlighter,
+                assertion_text_diff_style=assertion_util.get_assertion_text_diff_style(
+                    config
+                ),
+            )
+        )
+    else:
+        explanation_lines = assertion_util.assertrepr_compare(  # type: ignore[call-arg,assignment]
+            config=config, op=op, left=got, right=expected
+        )
     if explanation_lines:
         lines.extend(explanation_lines)
     else:


### PR DESCRIPTION
Private API :-/